### PR TITLE
add basic gotests support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Neovim (from v0.5) embeds a built-in Language Server Protocol (LSP) client. And 
 
 - Auto format with `:GoFormat` (via `goimports`, `gofmt`, and `gofumpt`) when saving.
 - Run linters with `:GoLint` (via `revive`) automatically.
-- Quickly test with `:GoTest`, `:GoTestFunc`, `:GoTestFile` and `:GoTestAll`.
+- Quickly test with `:GoTest`, `:GoTestFunc`, `:GoTestFile` and `:GoTestAll`. Generate test with `:GoAddTest`.
 - Import packages with `:GoGet` and `:GoImport`.
 - Modify struct tags with `:GoAddTags`, `:GoRemoveTags`, `:GoClearTags`, `:GoAddTagOptions`, `:GoRemoveTagOptions` and `:GoClearTagOptions`.
 - Generates JSON models with `:GoQuickType` (via `quicktype`).

--- a/after/ftplugin/go.vim
+++ b/after/ftplugin/go.vim
@@ -52,6 +52,9 @@ command! -nargs=* -range GoClearTagOptions lua require('go.struct_tag').clear_op
 " quicktype
 command! -nargs=* -complete=file GoQuickType lua require('go.quick_type').quick_type(<count>, <f-args>)
 
+" gotests add function test
+command! -nargs=* -complete=file GoAddTest lua require('go.gotests').add_test()
+
 lua << EOB
 local opt = require('go.config').options
 local cmd = vim.api.nvim_command

--- a/after/ftplugin/go.vim
+++ b/after/ftplugin/go.vim
@@ -34,6 +34,7 @@ command! GoTestAll lua require('go.test').test_all()
 command! GoTestFunc lua require('go.test').test_func()
 command! GoTestFile lua require('go.test').test_file()
 command! -nargs=? -complete=command GoToTest lua require('go.test').test_open(<f-args>)
+command! GoAddTest lua require('go.gotests').add_test()
 
 " import
 command! -nargs=1 GoGet lua require('go.import').get(<f-args>)
@@ -51,9 +52,6 @@ command! -nargs=* -range GoClearTagOptions lua require('go.struct_tag').clear_op
 
 " quicktype
 command! -nargs=* -complete=file GoQuickType lua require('go.quick_type').quick_type(<count>, <f-args>)
-
-" gotests add function test
-command! -nargs=* -complete=file GoAddTest lua require('go.gotests').add_test()
 
 lua << EOB
 local opt = require('go.config').options

--- a/doc/nvim-go.txt
+++ b/doc/nvim-go.txt
@@ -94,6 +94,9 @@ settings:
         tags_flags = {'-skip-unexported'},
         -- quick type
         quick_type_flags = {'--just-types'},
+        -- gotests
+        gotests_template = '',
+        gotests_template_dir = '',
     })
 <
                                                             *nvim-go-commands*
@@ -150,6 +153,9 @@ Commands~
 
 `:GoTestFile`                                                    *:GoTestFile*
     Run current `*_test.go` file.
+
+`:GoAddTest`                                                      *:GoAddTest*
+    Generate unit test for current function.
 
 `:GoToTest(cmd)`                                                   *:GoToTest*
     Go from `*.go` to `*_test.go` or go back. It will create new file if

--- a/lua/go/config.lua
+++ b/lua/go/config.lua
@@ -32,6 +32,7 @@ M.options = {
     tags_flags = { '-skip-unexported' },
     -- quick type
     quick_type_flags = { '--just-types' },
+    -- gotests
     gotests_template = '', -- sets gotests -template parameter (see gotests for details)
     gotests_template_dir = '', -- sets gotests -template_dir parameter (see gotests for details)
 }

--- a/lua/go/config.lua
+++ b/lua/go/config.lua
@@ -51,7 +51,7 @@ M.tools = {
     },
     { name = 'gomodifytags', src = 'github.com/fatih/gomodifytags' },
     { name = 'quicktype', src = 'quicktype', pkg_mgr = 'npm' },
-    { name = 'gotests', src = 'github.com/cweill/gotests' },
+    { name = 'gotests', src = 'github.com/cweill/gotests/gotests' },
 }
 
 function M.get_tool(name)

--- a/lua/go/config.lua
+++ b/lua/go/config.lua
@@ -32,6 +32,8 @@ M.options = {
     tags_flags = { '-skip-unexported' },
     -- quick type
     quick_type_flags = { '--just-types' },
+    gotests_template = '', -- sets gotests -template parameter (see gotests for details)
+    gotests_template_dir = '', -- sets gotests -template_dir parameter (see gotests for details)
 }
 
 M.tools = {
@@ -48,6 +50,7 @@ M.tools = {
     },
     { name = 'gomodifytags', src = 'github.com/fatih/gomodifytags' },
     { name = 'quicktype', src = 'quicktype', pkg_mgr = 'npm' },
+    { name = 'gotests', src = 'github.com/cweill/gotests' },
 }
 
 function M.get_tool(name)

--- a/lua/go/gotests.lua
+++ b/lua/go/gotests.lua
@@ -15,8 +15,7 @@ local function function_surrounding_cursor()
     local func = current_node
 
     while func do
-        if
-            func:type() == 'method_declaration'
+        if func:type() == 'method_declaration'
             or func:type() == 'function_declaration'
         then
             break
@@ -35,13 +34,11 @@ local function function_surrounding_cursor()
             local child = node:named_child(i)
             local type = child:type()
 
-            if
-                func:type() == 'method_declaration'
+            if func:type() == 'method_declaration'
                 and type == 'field_identifier'
             then
                 return (ts_utils.get_node_text(child))[1]
-            elseif
-                func:type() == 'function_declaration'
+            elseif func:type() == 'function_declaration'
                 and type == 'identifier'
             then
                 return (ts_utils.get_node_text(child))[1]
@@ -77,7 +74,7 @@ function M.add_test(_)
 
     local funame = function_surrounding_cursor()
     if funame == nil or funame == '' then
-        print('no function found')
+        output.show_error('no function found')
         return
     end
 

--- a/lua/go/gotests.lua
+++ b/lua/go/gotests.lua
@@ -1,0 +1,108 @@
+local M = {}
+
+local vim = vim
+local config = require('go.config')
+local output = require('go.output')
+
+local function function_surrounding_cursor()
+    local ts_utils = require('nvim-treesitter.ts_utils')
+    local current_node = ts_utils.get_node_at_cursor()
+
+    if not current_node then
+        return ''
+    end
+
+    local func = current_node
+
+    while func do
+        if
+            func:type() == 'method_declaration'
+            or func:type() == 'function_declaration'
+        then
+            break
+        end
+
+        func = func:parent()
+    end
+
+    if not func then
+        return ''
+    end
+
+    local find_name
+    find_name = function(node)
+        for i = 0, node:named_child_count() - 1, 1 do
+            local child = node:named_child(i)
+            local type = child:type()
+
+            if
+                func:type() == 'method_declaration'
+                and type == 'field_identifier'
+            then
+                return (ts_utils.get_node_text(child))[1]
+            elseif
+                func:type() == 'function_declaration'
+                and type == 'identifier'
+            then
+                return (ts_utils.get_node_text(child))[1]
+            else
+                local name = find_name(child)
+
+                if name then
+                    return name
+                end
+            end
+        end
+
+        return nil
+    end
+
+    return find_name(func)
+end
+
+function M.add_test(_)
+    local prefix = 'GoAddTest'
+    local cmd = { 'gotests' }
+
+    -- add extra args for templates
+    local opt = config.options
+    if string.len(opt.gotests_template) > 0 then
+        table.insert(cmd, '-template')
+        table.insert(cmd, opt.gotests_template)
+        if string.len(opt.gotests_template_dir) > 0 then
+            table.insert(cmd, '-template_dir')
+            table.insert(cmd, opt.gotests_template_dir)
+        end
+    end
+
+    local funame = function_surrounding_cursor()
+    if funame == nil or funame == '' then
+        print('no function found')
+        return
+    end
+
+    table.insert(cmd, '-only')
+    table.insert(cmd, funame)
+
+    local gofile = vim.fn.expand('%')
+    table.insert(cmd, '-w')
+    table.insert(cmd, gofile)
+
+    vim.fn.jobstart(cmd, {
+        stdout_buffered = true,
+        on_exit = function(_, code, _)
+            if code == 0 then
+                output.show_success(prefix, 'Success')
+            end
+        end,
+        on_stdout = function(_, data, _)
+            print('unit tests generate ' .. vim.inspect(data))
+        end,
+        on_stderr = function(_, data, _)
+            local results = table.concat(data, '\n')
+            output.show_error(prefix, results)
+        end,
+    })
+end
+
+return M

--- a/lua/go/gotests.lua
+++ b/lua/go/gotests.lua
@@ -61,7 +61,7 @@ local function function_surrounding_cursor()
     return find_name(func)
 end
 
-function M.add_test(_)
+function M.add_test()
     if not util.binary_exists('gotests') then
         return
     end


### PR DESCRIPTION
This adds basic support for https://github.com/cweill/gotests. Hovering over a function doing :GoAddTest adds test for function in _test.go file. I used treesitter to get the function name.

Sorry for the bad lua code, I've very basic knowledge of it, also credits go to https://github.com/ray-x/go.nvim for the idea and part of the code.