### PR TITLE
Add iferr implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Neovim (from v0.5) embeds a built-in Language Server Protocol (LSP) client. And 
 - Import packages with `:GoGet` and `:GoImport`.
 - Modify struct tags with `:GoAddTags`, `:GoRemoveTags`, `:GoClearTags`, `:GoAddTagOptions`, `:GoRemoveTagOptions` and `:GoClearTagOptions`.
 - Generates JSON models with `:GoQuickType` (via `quicktype`).
+- Generate if err based on function return values with `:GoIfErr` (via `iferr`).
 
 [Screenshots](https://github.com/crispgm/nvim-go/wiki#screenshots)
 

--- a/after/ftplugin/go.vim
+++ b/after/ftplugin/go.vim
@@ -54,7 +54,7 @@ command! -nargs=* -range GoClearTagOptions lua require('go.struct_tag').clear_op
 command! -nargs=* -complete=file GoQuickType lua require('go.quick_type').quick_type(<count>, <f-args>)
 
 " iferr
-command! -nargs=* -complete=file GoIfErr lua require('go.iferr').add_iferr()
+command! GoIfErr lua require('go.iferr').add_iferr()
 
 lua << EOB
 local opt = require('go.config').options

--- a/after/ftplugin/go.vim
+++ b/after/ftplugin/go.vim
@@ -53,6 +53,9 @@ command! -nargs=* -range GoClearTagOptions lua require('go.struct_tag').clear_op
 " quicktype
 command! -nargs=* -complete=file GoQuickType lua require('go.quick_type').quick_type(<count>, <f-args>)
 
+" iferr
+command! -nargs=* -complete=file GoIfErr lua require('go.iferr').add_iferr()
+
 lua << EOB
 local opt = require('go.config').options
 local cmd = vim.api.nvim_command

--- a/lua/go/config.lua
+++ b/lua/go/config.lua
@@ -52,6 +52,7 @@ M.tools = {
     { name = 'gomodifytags', src = 'github.com/fatih/gomodifytags' },
     { name = 'quicktype', src = 'quicktype', pkg_mgr = 'npm' },
     { name = 'gotests', src = 'github.com/cweill/gotests/gotests' },
+    { name = 'iferr', src = 'github.com/koron/iferr' },
 }
 
 function M.get_tool(name)

--- a/lua/go/iferr.lua
+++ b/lua/go/iferr.lua
@@ -1,0 +1,31 @@
+local M = {}
+
+local vim = vim
+local config = require('go.config')
+local output = require('go.output')
+local util = require('go.util')
+
+function M.add_iferr()
+    if not util.binary_exists('iferr') then
+        return
+    end
+    local prefix = 'GoIfErr'
+    local boff = vim.fn.wordcount().cursor_bytes
+    local cmd = (config.get_tool('iferr').name .. ' -pos ' .. boff)
+    local data = vim.fn.systemlist(cmd, vim.fn.bufnr('%'))
+
+    if vim.v.shell_error ~= 0 then
+        output.show_error(
+            prefix,
+            'command ' .. cmd .. ' exited with code ' .. vim.v.shell_error
+        )
+        return
+    end
+
+    local pos = vim.fn.getcurpos()[2]
+    vim.fn.append(pos, data)
+    vim.cmd([[silent normal! j=2j]])
+    vim.fn.setpos('.', pos)
+end
+
+return M


### PR DESCRIPTION
This adds support for https://github.com/koron/iferr to easily add "if err != nil" blocks to the code. Just hover above an err definition statement and call :GoIfErr and the block is added including proper return values based on function return values.