### PR TITLE
Async go test run into Vim-loclist with help of -json flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,12 @@ require('go').setup({
     -- maintain cursor position after formatting loaded buffer
     maintain_cursor_pos = false,
     -- test flags: -count=1 will disable cache
+    -- test flags: -json will replace test_popup with async loclist filling
     test_flags = {'-v'},
     test_timeout = '30s',
     test_env = {},
     -- show test result with popup window
+    -- note! '-json' go test flag replaces the popup with a loclist
     test_popup = true,
     test_popup_auto_leave = false,
     test_popup_width = 80,

--- a/doc/nvim-go.txt
+++ b/doc/nvim-go.txt
@@ -79,10 +79,12 @@ settings:
         -- maintain cursor position after formatting loaded buffer
         maintain_cursor_pos = false,
         -- test flags: -count=1 will disable cache
+        -- test flags: -json will replace test_popup with async loclist filling
         test_flags = {'-v'},
         test_timeout = '30s',
         test_env = {},
         -- show test result with popup window
+        -- note! '-json' go test flag replaces the popup with a loclist
         test_popup = true,
         test_popup_auto_leave = false,
         test_popup_width = 80,

--- a/lua/go/async_test.lua
+++ b/lua/go/async_test.lua
@@ -281,7 +281,7 @@ function M.do_test(prefix, cmd)
         end
     end
 
-    local cwd = calc_working_dir(prefix)
+    local cwd = M.calc_working_dir(prefix)
     local env = config.options.test_env
     local opts = {
         on_exit = function(_, code, _)

--- a/lua/go/async_test.lua
+++ b/lua/go/async_test.lua
@@ -239,7 +239,7 @@ local function module_root(cwd)
     return working_dir
 end
 
-local function calc_working_dir(prefix)
+function M.calc_working_dir(prefix)
     -- Only 'go test' cmd is run in the buffer's dir
     if prefix == 'GoTest' then
         return vim.fn.expand('%:p:h')

--- a/lua/go/async_test.lua
+++ b/lua/go/async_test.lua
@@ -195,7 +195,9 @@ local function quickfix(prefix)
         out.win_nr = win_nr
     end
     out.clear = function()
-        if not out.win_nr then return end
+        if not out.win_nr then
+            out.win_nr = vim.fn.winnr()
+        end
         vim.fn.setloclist(out.win_nr, {})
         vim.api.nvim_command('lclose')
     end

--- a/lua/go/async_test.lua
+++ b/lua/go/async_test.lua
@@ -1,0 +1,259 @@
+local M = {}
+
+local vim = vim
+local config = require('go.config')
+local util = require('go.util')
+local output = require('go.output')
+
+local correctly_formatted = "^    .+%.go:%d+: .+$"
+
+local function queue()
+    local out = {}
+    out.push = function(item)
+        table.insert(out, 1, item)
+    end
+    out.pop = function()
+        if #out > 0 then
+            return table.remove(out, #out)
+        end
+    end
+    out.iterator = function()
+        return function()
+            return out.pop()
+        end
+    end
+    return out
+end
+
+local function test()
+    local out = { lines = queue() }
+    out.add_msg = function(msg)
+        if string.match(msg, correctly_formatted) then
+            out.lines.push(msg)
+        end
+    end
+    out.last_msgs = function()
+        return out.lines.iterator()
+    end
+    out.last_msg = function()
+        return out.lines.pop()
+    end
+    return out
+end
+
+local function split_and_rev_cwd(dir)
+    local rev_pwd = {}
+    local working_dir = dir and dir or vim.fn.getcwd()
+    local split_pwd = vim.fn.split(working_dir, "/")
+    for i = #split_pwd, 1, -1 do
+        rev_pwd[#rev_pwd + 1] = split_pwd[i]
+    end
+    return rev_pwd
+end
+
+local function calc_relative_path_to(pn, cwd)
+    local rev_pwd = split_and_rev_cwd(cwd)
+    local rev_pn = split_and_rev_cwd(pn)
+    local spn = vim.fn.split(pn, "/")
+
+    local go_down = ""
+    local common = nil
+    for _, pwd1 in ipairs(rev_pwd) do
+        local common_i = nil
+        for i, p1 in ipairs(rev_pn) do
+            if p1 == pwd1 then
+                common_i = i
+                break
+            end
+        end
+        if not common_i then
+            go_down = go_down .. "../"
+        else
+            common = common_i
+            break
+        end
+    end
+
+    local path_to = go_down
+    for i = #spn - common + 1 + 1, #spn do -- +1 index correx +1 common dir remove
+        path_to = path_to .. spn[i] .. "/"
+    end
+    return path_to
+end
+
+local function parse_qf_line(qf_list, test_event)
+    if string.match(test_event.Msg, correctly_formatted) then
+        local path_to_testfile = calc_relative_path_to(test_event.Package)
+        local path_corrected_msg = string.gsub(
+            test_event.Msg,
+            "^    ",
+            path_to_testfile
+        )
+        local filename, lnum, text = string.match(
+            path_corrected_msg,
+            "^(.+%.go):(%d+): (.+)$"
+        )
+        table.insert(qf_list, {
+            filename = filename,
+            lnum = lnum,
+            type = 'E',
+            module = test_event.Name,
+            text = text,
+        })
+    end
+end
+
+local function parse_output_lines(test_event)
+    local qf_list = {}
+    for msg in test_event.Messages do
+        test_event.Msg = msg
+        parse_qf_line(qf_list, test_event)
+    end
+    return qf_list
+end
+
+local function test_run()
+    local out = { current_test = {}, list = {} }
+    out.parse_test_output_line = function(line, process)
+        if not line or line == "" then return end
+        local test_event = vim.fn.json_decode(line)
+        if not test_event.Test or test_event.Test == "" then return end
+
+        local action = test_event.Action
+        local tkey = test_event.Package .. test_event.Test
+
+        if action == "run" then
+            out.current_test[tkey] = test()
+        elseif action == "fail" then
+            if not out.current_test[tkey] then return end
+            local qf_list = parse_output_lines({
+                Messages = out.current_test[tkey].last_msgs(),
+                Package = test_event.Package,
+                Name = test_event.Test,
+            })
+            if qf_list ~= nil and #qf_list > 0 then
+                process(qf_list)
+            end
+            out.current_test[tkey] = nil
+        elseif action == "output" then
+            if not out.current_test[tkey] then return end
+            out.current_test[tkey].add_msg(test_event.Output)
+        elseif action == "pass" then
+            out.current_test[tkey] = nil
+        end
+    end
+
+    return out
+end
+
+local function quickfix(prefix)
+    local out = { win_nr = nil, title = prefix }
+    out.show = function(qf_list)
+        if not qf_list then return end
+
+        if out.win_nr ~= nil then
+            vim.fn.setloclist(out.win_nr, qf_list, 'a')
+            return
+        end
+
+        local win_nr = vim.fn.winnr()
+        local height = vim.o.lines / 5 -- 20% of the height
+        height = height < 3 and 3 or height
+        local title = out.title and out.title or "go test result"
+
+        vim.fn.setloclist(win_nr, qf_list, 'r')
+        vim.fn.setloclist(win_nr, {}, 'a', { title = title })
+        vim.api.nvim_command(string.format('lopen %d', height))
+        out.win_nr = win_nr
+    end
+    out.clear = function()
+        if not out.win_nr then return end
+        vim.fn.setloclist(out.win_nr, {})
+        vim.api.nvim_command('lclose')
+    end
+    out.is_on = function()
+        return out.win_nr ~= nil
+    end
+    return out
+end
+
+local function sub_path(rev_path, cut_count)
+    local path = ""
+    for i = 1, #rev_path - cut_count do
+        if i == 1 and rev_path[i] ~= "."
+            and not string.find(rev_path[i], "/")
+        then
+            path = "/"
+        end
+        path = path .. rev_path[i] .. "/"
+    end
+    return path
+end
+
+local function module_root(cwd)
+    local working_dir = cwd and cwd or vim.fn.getcwd()
+    local rev_cwd = vim.fn.split(working_dir, "/")
+    for i = 0, #rev_cwd do
+        local sb = sub_path(rev_cwd, i)
+        if util.is_file(sb .. "go.mod") then
+            return sb
+        end
+    end
+    return working_dir
+end
+
+local function calc_working_dir(prefix)
+    local cwd = vim.fn.expand('%:p:h')
+    if prefix == "GoTestAll" then
+        cwd = module_root()
+    end
+    return cwd
+end
+
+function M.do_test(prefix, cmd)
+    if not util.valid_buf() then
+        return
+    end
+    local qf_win = quickfix(prefix)
+    local trun = test_run()
+    local function on_event(_, data, _)
+        if not util.empty_output(data) then
+            for _, line in ipairs(data) do
+                trun.parse_test_output_line(line, function(qfl)
+                    qf_win.show(qfl)
+                end)
+            end
+        end
+    end
+
+    local cwd = calc_working_dir(prefix)
+    local env = config.options.test_env
+    local opts = {
+        on_exit = function(_, code, _)
+            if code ~= 0 then
+                output.show_warning(
+                    prefix,
+                    string.format('error code: %d', code)
+                )
+            elseif not qf_win.is_on() then
+                qf_win.clear()
+                output.show_info(prefix, "✅ PASS")
+            end
+        end,
+        cwd = cwd,
+        on_stdout = on_event,
+        on_stderr = on_event,
+    }
+    if env ~= nil and next(env) ~= nil then
+        opts['env'] = env
+    end
+    vim.fn.jobstart(cmd, opts)
+end
+
+-- export for testing
+M._calc_relative_path_to = calc_relative_path_to
+M._module_root = module_root
+M._test_run = test_run
+
+return M
+

--- a/lua/go/async_test.lua
+++ b/lua/go/async_test.lua
@@ -240,11 +240,11 @@ local function module_root(cwd)
 end
 
 local function calc_working_dir(prefix)
-    local cwd = vim.fn.expand('%:p:h')
-    if prefix == 'GoTestAll' then
-        cwd = module_root()
+    -- Only 'go test' cmd is run in the buffer's dir
+    if prefix == 'GoTest' then
+        return vim.fn.expand('%:p:h')
     end
-    return cwd
+    return module_root()
 end
 
 function M.do_test(prefix, cmd)

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -94,7 +94,7 @@ local function sync_do_test(prefix, cmd)
         end
     end
 
-    local cwd = vim.fn.expand('%:p:h')
+    local cwd = async.calc_working_dir(prefix)
     local env = config.options.test_env
     local opts = {
         on_exit = function(_, code, _)

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -16,7 +16,7 @@ local function build_args(args)
     local test_flags = config.options.test_flags
     if test_flags then
         for _, f in ipairs(test_flags) do
-            if string.match(f, "-json") then
+            if string.match(f, '-json') then
                 use_qf_output = true
             end
             table.insert(args, f)

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -31,6 +31,11 @@ local function build_args(args)
     return table.concat(args, ' ')
 end
 
+local function package_name_test_target()
+    local cwd = vim.fn.expand('%:p:h')
+    return cwd .. '/...'
+end
+
 local function valid_func_name(func_name)
     if not func_name then
         return false
@@ -174,6 +179,7 @@ function M.test_func(opt)
         'test',
         '-run',
         vim.fn.shellescape(string.format('^%s$', func_name)),
+        package_name_test_target(),
     }
     do_test(prefix, build_args(cmd))
 end
@@ -207,6 +213,7 @@ function M.test_file()
         vim.fn.shellescape(
             table.concat(func_names, '|') -- we need sub tests as well
         ),
+        package_name_test_target(),
     }
     do_test(prefix, build_args(cmd))
 end

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -4,6 +4,9 @@ local vim = vim
 local config = require('go.config')
 local util = require('go.util')
 local output = require('go.output')
+local async = require('go.async_test')
+
+local use_qf_output = false
 
 local function build_args(args)
     local test_timeout = config.options.test_timeout
@@ -13,6 +16,9 @@ local function build_args(args)
     local test_flags = config.options.test_flags
     if test_flags then
         for _, f in ipairs(test_flags) do
+            if string.match(f, "-json") then
+                use_qf_output = true
+            end
             table.insert(args, f)
         end
     end
@@ -40,20 +46,8 @@ local function split_file_name(str)
     return vim.fn.split(vim.fn.split(str, ' ')[2], '(')[1]
 end
 
-local function valid_buf()
-    local buf_nr = vim.api.nvim_get_current_buf()
-    if
-        vim.api.nvim_buf_is_valid(buf_nr)
-        and vim.api.nvim_buf_get_option(buf_nr, 'buflisted')
-    then
-        return true
-    end
-
-    return false
-end
-
-local function do_test(prefix, cmd)
-    if not valid_buf() then
+local function sync_do_test(prefix, cmd)
+    if not util.valid_buf() then
         return
     end
     -- calc popup window size here
@@ -113,6 +107,14 @@ local function do_test(prefix, cmd)
         opts['env'] = env
     end
     vim.fn.jobstart(cmd, opts)
+end
+
+local function do_test(prefix, cmd)
+    if use_qf_output then
+        async.do_test(prefix, cmd)
+    else
+        sync_do_test(prefix, cmd)
+    end
 end
 
 function M.test()
@@ -200,7 +202,7 @@ function M.test_file()
         'test',
         '-run',
         vim.fn.shellescape(
-            string.format('^%s$', table.concat(func_names, '|'))
+            table.concat(func_names, '|') -- we need sub tests as well
         ),
     }
     do_test(prefix, build_args(cmd))

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -22,8 +22,11 @@ local function build_args(args)
             table.insert(args, f)
         end
     end
-    -- redirect stderr to stdout so neovim won't crash
-    table.insert(args, '2>&1')
+    -- we need compiler error messages from stderr in -json output parsing
+    if not use_qf_output then
+        -- redirect stderr to stdout so neovim won't crash
+        table.insert(args, '2>&1')
+    end
 
     return table.concat(args, ' ')
 end

--- a/lua/go/util.lua
+++ b/lua/go/util.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local vim = vim
+local uv = vim.loop
 local output = require('go.output')
 
 function M.current_word()
@@ -31,6 +32,31 @@ function M.empty_output(data)
     end
 
     return false
+end
+
+function M.valid_buf()
+    local buf_nr = vim.api.nvim_get_current_buf()
+    if
+        vim.api.nvim_buf_is_valid(buf_nr)
+        and vim.api.nvim_buf_get_option(buf_nr, 'buflisted')
+    then
+        return true
+    end
+
+    return false
+end
+
+function M.exists(filename)
+    local stat = uv.fs_stat(filename)
+    return stat and stat.type or false
+end
+
+function M.is_dir(filename)
+    return M.exists(filename) == 'directory'
+end
+
+function M.is_file(filename)
+    return M.exists(filename) == 'file'
 end
 
 return M

--- a/lua/tests/specs/async_test_spec.lua
+++ b/lua/tests/specs/async_test_spec.lua
@@ -2,44 +2,60 @@ local test = require('go.async_test')
 
 describe('async test utilities', function()
     it('should calc relative path to test file from working dir', function()
-        assert.are.same("d/",
-            test._calc_relative_path_to("a/b/c/d", "a/b/c"))
-        assert.are.same("dd/",
-            test._calc_relative_path_to("aa/bb/cc/dd", "aa/bc/cc"))
-        assert.are.same("../",
-            test._calc_relative_path_to("a/b/c", "a/b/c/d"))
-        assert.are.same("../../../",
-            test._calc_relative_path_to("a/b/c", "a/b/c/d/e/f"))
-        assert.are.same("d/e/f/",
-            test._calc_relative_path_to("a/b/c/d/e/f", "a/b/c"))
-        assert.are.same("ddddd/eeeee/fffff/",
-            test._calc_relative_path_to("aaaaa/bbbbb/ccccc/ddddd/eeeee/fffff",
-                "aaaaa/bbbbb/ccccc"))
+        assert.are.same('d/', test._calc_relative_path_to('a/b/c/d', 'a/b/c'))
+        assert.are.same(
+            'dd/',
+            test._calc_relative_path_to('aa/bb/cc/dd', 'aa/bc/cc')
+        )
+        assert.are.same('../', test._calc_relative_path_to('a/b/c', 'a/b/c/d'))
+        assert.are.same(
+            '../../../',
+            test._calc_relative_path_to('a/b/c', 'a/b/c/d/e/f')
+        )
+        assert.are.same(
+            'd/e/f/',
+            test._calc_relative_path_to('a/b/c/d/e/f', 'a/b/c')
+        )
+        assert.are.same(
+            'ddddd/eeeee/fffff/',
+            test._calc_relative_path_to(
+                'aaaaa/bbbbb/ccccc/ddddd/eeeee/fffff',
+                'aaaaa/bbbbb/ccccc'
+            )
+        )
     end)
 
     it('should calc module root path above current dir', function()
         -- path below includes 'go.mod' file which's used  for module root
         -- detection
 
-        assert.are.same("./test/fixtures/test/",
-            test._module_root("./test/fixtures/test/test/test"))
-        assert.are.same("./test/fixtures/test/",
-            test._module_root("./test/fixtures/test/test/"))
-        assert.are.same("./test/fixtures/test/",
-            test._module_root("./test/fixtures/test"))
+        assert.are.same(
+            './test/fixtures/test/',
+            test._module_root('./test/fixtures/test/test/test')
+        )
+        assert.are.same(
+            './test/fixtures/test/',
+            test._module_root('./test/fixtures/test/test/')
+        )
+        assert.are.same(
+            './test/fixtures/test/',
+            test._module_root('./test/fixtures/test')
+        )
 
         local cwd = vim.fn.getcwd() -- to test root '/' calculation
-        assert.are.same(cwd .. "/test/fixtures/test/",
-            test._module_root(cwd .. "/test/fixtures/test/test/test"))
+        assert.are.same(
+            cwd .. '/test/fixtures/test/',
+            test._module_root(cwd .. '/test/fixtures/test/test/test')
+        )
     end)
 end)
 
 describe('async test run', function()
     local run_pseudo_test = function(fn, count)
         local org_cwd = vim.fn.getcwd()
-        vim.api.nvim_set_current_dir("./test/fixtures/test")
+        vim.api.nvim_set_current_dir('./test/fixtures/test')
         local file = io.open(fn)
-        assert(file, "must exist")
+        assert(file, 'must exist')
         local lines = file:lines()
         local trun = test._test_run()
         local fail_count = 0
@@ -53,20 +69,19 @@ describe('async test run', function()
     end
 
     it('should find ZERO when all pass', function()
-        run_pseudo_test("pass_test.json", 0)
+        run_pseudo_test('pass_test.json', 0)
     end)
 
     it('should find failed ones', function()
-        run_pseudo_test("fail_test.json", 2)
+        run_pseudo_test('fail_test.json', 2)
     end)
 
     it('should find failed ones for sub tests as well', function()
-        run_pseudo_test("fail_include_sub_tests.json", 6)
+        run_pseudo_test('fail_include_sub_tests.json', 6)
     end)
 
     it('should find failed ones from examples', function()
         -- 8 errors 4 info lines 1 caption
-        run_pseudo_test("example-test-fail.json", 8*(4+1))
+        run_pseudo_test('example-test-fail.json', 8 * (4 + 1))
     end)
 end)
-

--- a/lua/tests/specs/async_test_spec.lua
+++ b/lua/tests/specs/async_test_spec.lua
@@ -63,5 +63,10 @@ describe('async test run', function()
     it('should find failed ones for sub tests as well', function()
         run_pseudo_test("fail_include_sub_tests.json", 6)
     end)
+
+    it('should find failed ones from examples', function()
+        -- 8 errors 4 info lines 1 caption
+        run_pseudo_test("example-test-fail.json", 8*(4+1))
+    end)
 end)
 

--- a/lua/tests/specs/async_test_spec.lua
+++ b/lua/tests/specs/async_test_spec.lua
@@ -1,0 +1,67 @@
+local test = require('go.async_test')
+
+describe('async test utilities', function()
+    it('should calc relative path to test file from working dir', function()
+        assert.are.same("d/",
+            test._calc_relative_path_to("a/b/c/d", "a/b/c"))
+        assert.are.same("dd/",
+            test._calc_relative_path_to("aa/bb/cc/dd", "aa/bc/cc"))
+        assert.are.same("../",
+            test._calc_relative_path_to("a/b/c", "a/b/c/d"))
+        assert.are.same("../../../",
+            test._calc_relative_path_to("a/b/c", "a/b/c/d/e/f"))
+        assert.are.same("d/e/f/",
+            test._calc_relative_path_to("a/b/c/d/e/f", "a/b/c"))
+        assert.are.same("ddddd/eeeee/fffff/",
+            test._calc_relative_path_to("aaaaa/bbbbb/ccccc/ddddd/eeeee/fffff",
+                "aaaaa/bbbbb/ccccc"))
+    end)
+
+    it('should calc module root path above current dir', function()
+        -- path below includes 'go.mod' file which's used  for module root
+        -- detection
+
+        assert.are.same("./test/fixtures/test/",
+            test._module_root("./test/fixtures/test/test/test"))
+        assert.are.same("./test/fixtures/test/",
+            test._module_root("./test/fixtures/test/test/"))
+        assert.are.same("./test/fixtures/test/",
+            test._module_root("./test/fixtures/test"))
+
+        local cwd = vim.fn.getcwd() -- to test root '/' calculation
+        assert.are.same(cwd .. "/test/fixtures/test/",
+            test._module_root(cwd .. "/test/fixtures/test/test/test"))
+    end)
+end)
+
+describe('async test run', function()
+    local run_pseudo_test = function(fn, count)
+        local org_cwd = vim.fn.getcwd()
+        vim.api.nvim_set_current_dir("./test/fixtures/test")
+        local file = io.open(fn)
+        assert(file, "must exist")
+        local lines = file:lines()
+        local trun = test._test_run()
+        local fail_count = 0
+        for line in lines do
+            trun.parse_test_output_line(line, function(qfl)
+                fail_count = fail_count + #qfl
+            end)
+        end
+        vim.api.nvim_set_current_dir(org_cwd)
+        assert.are.same(count, fail_count)
+    end
+
+    it('should find ZERO when all pass', function()
+        run_pseudo_test("pass_test.json", 0)
+    end)
+
+    it('should find failed ones', function()
+        run_pseudo_test("fail_test.json", 2)
+    end)
+
+    it('should find failed ones for sub tests as well', function()
+        run_pseudo_test("fail_include_sub_tests.json", 6)
+    end)
+end)
+

--- a/test/fixtures/test/example-test-fail.json
+++ b/test/fixtures/test/example-test-fail.json
@@ -1,0 +1,430 @@
+{"Time":"2022-08-09T20:26:30.807099+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName"}
+{"Time":"2022-08-09T20:26:30.807246+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName","Output":"=== RUN   TestFullName\n"}
+{"Time":"2022-08-09T20:26:30.807257+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/all_empty"}
+{"Time":"2022-08-09T20:26:30.807263+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/all_empty","Output":"=== RUN   TestFullName/all_empty\n"}
+{"Time":"2022-08-09T20:26:30.807269+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/namespaces"}
+{"Time":"2022-08-09T20:26:30.807273+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/namespaces","Output":"=== RUN   TestFullName/namespaces\n"}
+{"Time":"2022-08-09T20:26:30.807278+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/both"}
+{"Time":"2022-08-09T20:26:30.807282+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/both","Output":"=== RUN   TestFullName/both\n"}
+{"Time":"2022-08-09T20:26:30.807295+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/func"}
+{"Time":"2022-08-09T20:26:30.8073+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/func","Output":"=== RUN   TestFullName/func\n"}
+{"Time":"2022-08-09T20:26:30.807307+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName","Output":"--- PASS: TestFullName (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807311+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/all_empty","Output":"    --- PASS: TestFullName/all_empty (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807318+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/all_empty","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.80733+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/namespaces","Output":"    --- PASS: TestFullName/namespaces (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807336+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/namespaces","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.80734+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/both","Output":"    --- PASS: TestFullName/both (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807345+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/both","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807351+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/func","Output":"    --- PASS: TestFullName/func (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807358+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName/func","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807363+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestFullName","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807367+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor"}
+{"Time":"2022-08-09T20:26:30.807371+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor","Output":"=== RUN   TestIsAnchor\n"}
+{"Time":"2022-08-09T20:26:30.807376+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/panic_func_and_short_regexp"}
+{"Time":"2022-08-09T20:26:30.80738+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/panic_func_and_short_regexp","Output":"=== RUN   TestIsAnchor/panic_func_and_short_regexp\n"}
+{"Time":"2022-08-09T20:26:30.807386+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/func_hit_and_regexp_on"}
+{"Time":"2022-08-09T20:26:30.807402+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/func_hit_and_regexp_on","Output":"=== RUN   TestIsAnchor/func_hit_and_regexp_on\n"}
+{"Time":"2022-08-09T20:26:30.807405+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp_no_match"}
+{"Time":"2022-08-09T20:26:30.807407+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp_no_match","Output":"=== RUN   TestIsAnchor/short_regexp_no_match\n"}
+{"Time":"2022-08-09T20:26:30.80741+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp"}
+{"Time":"2022-08-09T20:26:30.807412+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp","Output":"=== RUN   TestIsAnchor/short_regexp\n"}
+{"Time":"2022-08-09T20:26:30.807415+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short"}
+{"Time":"2022-08-09T20:26:30.807417+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short","Output":"=== RUN   TestIsAnchor/short\n"}
+{"Time":"2022-08-09T20:26:30.80742+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short-but-false"}
+{"Time":"2022-08-09T20:26:30.807422+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short-but-false","Output":"=== RUN   TestIsAnchor/short-but-false\n"}
+{"Time":"2022-08-09T20:26:30.807425+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium"}
+{"Time":"2022-08-09T20:26:30.807427+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium","Output":"=== RUN   TestIsAnchor/medium\n"}
+{"Time":"2022-08-09T20:26:30.80743+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium-but-false"}
+{"Time":"2022-08-09T20:26:30.807433+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium-but-false","Output":"=== RUN   TestIsAnchor/medium-but-false\n"}
+{"Time":"2022-08-09T20:26:30.807436+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/long"}
+{"Time":"2022-08-09T20:26:30.807439+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/long","Output":"=== RUN   TestIsAnchor/long\n"}
+{"Time":"2022-08-09T20:26:30.807442+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/package_name_only"}
+{"Time":"2022-08-09T20:26:30.807444+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/package_name_only","Output":"=== RUN   TestIsAnchor/package_name_only\n"}
+{"Time":"2022-08-09T20:26:30.807447+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor","Output":"--- PASS: TestIsAnchor (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80745+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/panic_func_and_short_regexp","Output":"    --- PASS: TestIsAnchor/panic_func_and_short_regexp (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807456+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/panic_func_and_short_regexp","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807459+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/func_hit_and_regexp_on","Output":"    --- PASS: TestIsAnchor/func_hit_and_regexp_on (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807463+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/func_hit_and_regexp_on","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807465+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp_no_match","Output":"    --- PASS: TestIsAnchor/short_regexp_no_match (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807474+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp_no_match","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807477+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp","Output":"    --- PASS: TestIsAnchor/short_regexp (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80748+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short_regexp","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807482+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short","Output":"    --- PASS: TestIsAnchor/short (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807485+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807488+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short-but-false","Output":"    --- PASS: TestIsAnchor/short-but-false (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807491+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/short-but-false","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807494+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium","Output":"    --- PASS: TestIsAnchor/medium (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807497+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.8075+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium-but-false","Output":"    --- PASS: TestIsAnchor/medium-but-false (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807502+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/medium-but-false","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807507+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/long","Output":"    --- PASS: TestIsAnchor/long (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80751+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/long","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807513+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/package_name_only","Output":"    --- PASS: TestIsAnchor/package_name_only (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807516+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor/package_name_only","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807519+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsAnchor","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807522+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor"}
+{"Time":"2022-08-09T20:26:30.807524+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor","Output":"=== RUN   TestIsFuncAnchor\n"}
+{"Time":"2022-08-09T20:26:30.807527+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/func_hit_and_regexp_on"}
+{"Time":"2022-08-09T20:26:30.80753+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/func_hit_and_regexp_on","Output":"=== RUN   TestIsFuncAnchor/func_hit_and_regexp_on\n"}
+{"Time":"2022-08-09T20:26:30.807533+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short_regexp"}
+{"Time":"2022-08-09T20:26:30.807536+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short_regexp","Output":"=== RUN   TestIsFuncAnchor/short_regexp\n"}
+{"Time":"2022-08-09T20:26:30.807539+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short"}
+{"Time":"2022-08-09T20:26:30.807547+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short","Output":"=== RUN   TestIsFuncAnchor/short\n"}
+{"Time":"2022-08-09T20:26:30.80755+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short-but-false"}
+{"Time":"2022-08-09T20:26:30.807552+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short-but-false","Output":"=== RUN   TestIsFuncAnchor/short-but-false\n"}
+{"Time":"2022-08-09T20:26:30.807555+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium"}
+{"Time":"2022-08-09T20:26:30.807558+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium","Output":"=== RUN   TestIsFuncAnchor/medium\n"}
+{"Time":"2022-08-09T20:26:30.807561+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium-but-false"}
+{"Time":"2022-08-09T20:26:30.807564+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium-but-false","Output":"=== RUN   TestIsFuncAnchor/medium-but-false\n"}
+{"Time":"2022-08-09T20:26:30.807567+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/long"}
+{"Time":"2022-08-09T20:26:30.807569+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/long","Output":"=== RUN   TestIsFuncAnchor/long\n"}
+{"Time":"2022-08-09T20:26:30.807573+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/package_name_only"}
+{"Time":"2022-08-09T20:26:30.807575+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/package_name_only","Output":"=== RUN   TestIsFuncAnchor/package_name_only\n"}
+{"Time":"2022-08-09T20:26:30.807578+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor","Output":"--- PASS: TestIsFuncAnchor (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807581+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/func_hit_and_regexp_on","Output":"    --- PASS: TestIsFuncAnchor/func_hit_and_regexp_on (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807584+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/func_hit_and_regexp_on","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807586+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short_regexp","Output":"    --- PASS: TestIsFuncAnchor/short_regexp (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807589+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short_regexp","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807592+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short","Output":"    --- PASS: TestIsFuncAnchor/short (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807595+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807598+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short-but-false","Output":"    --- PASS: TestIsFuncAnchor/short-but-false (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.8076+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/short-but-false","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807603+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium","Output":"    --- PASS: TestIsFuncAnchor/medium (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807606+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807609+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium-but-false","Output":"    --- PASS: TestIsFuncAnchor/medium-but-false (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807618+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/medium-but-false","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807621+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/long","Output":"    --- PASS: TestIsFuncAnchor/long (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807624+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/long","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807627+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/package_name_only","Output":"    --- PASS: TestIsFuncAnchor/package_name_only (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80763+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor/package_name_only","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807632+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestIsFuncAnchor","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807635+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits"}
+{"Time":"2022-08-09T20:26:30.807637+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits","Output":"=== RUN   TestStackPrint_noLimits\n"}
+{"Time":"2022-08-09T20:26:30.80764+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/short"}
+{"Time":"2022-08-09T20:26:30.807643+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/short","Output":"=== RUN   TestStackPrint_noLimits/short\n"}
+{"Time":"2022-08-09T20:26:30.80765+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/medium"}
+{"Time":"2022-08-09T20:26:30.807652+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/medium","Output":"=== RUN   TestStackPrint_noLimits/medium\n"}
+{"Time":"2022-08-09T20:26:30.807655+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/long"}
+{"Time":"2022-08-09T20:26:30.807658+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/long","Output":"=== RUN   TestStackPrint_noLimits/long\n"}
+{"Time":"2022-08-09T20:26:30.807661+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits","Output":"--- PASS: TestStackPrint_noLimits (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807664+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/short","Output":"    --- PASS: TestStackPrint_noLimits/short (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807667+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/short","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807671+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/medium","Output":"    --- PASS: TestStackPrint_noLimits/medium (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807674+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/medium","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807676+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/long","Output":"    --- PASS: TestStackPrint_noLimits/long (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807679+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits/long","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807681+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_noLimits","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807689+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor"}
+{"Time":"2022-08-09T20:26:30.807691+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor","Output":"=== RUN   TestCalcAnchor\n"}
+{"Time":"2022-08-09T20:26:30.807694+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_regexp"}
+{"Time":"2022-08-09T20:26:30.807697+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_regexp","Output":"=== RUN   TestCalcAnchor/macOS_from_test_using_regexp\n"}
+{"Time":"2022-08-09T20:26:30.8077+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short"}
+{"Time":"2022-08-09T20:26:30.807702+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short","Output":"=== RUN   TestCalcAnchor/short\n"}
+{"Time":"2022-08-09T20:26:30.807705+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_error_stack"}
+{"Time":"2022-08-09T20:26:30.807707+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_error_stack","Output":"=== RUN   TestCalcAnchor/short_error_stack\n"}
+{"Time":"2022-08-09T20:26:30.80771+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_and_nolimit"}
+{"Time":"2022-08-09T20:26:30.807712+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_and_nolimit","Output":"=== RUN   TestCalcAnchor/short_and_nolimit\n"}
+{"Time":"2022-08-09T20:26:30.807715+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/medium"}
+{"Time":"2022-08-09T20:26:30.807717+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/medium","Output":"=== RUN   TestCalcAnchor/medium\n"}
+{"Time":"2022-08-09T20:26:30.80772+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test_using_panic"}
+{"Time":"2022-08-09T20:26:30.807723+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test_using_panic","Output":"=== RUN   TestCalcAnchor/from_test_using_panic\n"}
+{"Time":"2022-08-09T20:26:30.807725+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test"}
+{"Time":"2022-08-09T20:26:30.807728+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test","Output":"=== RUN   TestCalcAnchor/from_test\n"}
+{"Time":"2022-08-09T20:26:30.80773+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_panic"}
+{"Time":"2022-08-09T20:26:30.807733+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_panic","Output":"=== RUN   TestCalcAnchor/macOS_from_test_using_panic\n"}
+{"Time":"2022-08-09T20:26:30.807736+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor","Output":"--- PASS: TestCalcAnchor (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807739+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_regexp","Output":"    --- PASS: TestCalcAnchor/macOS_from_test_using_regexp (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807742+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_regexp","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807745+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short","Output":"    --- PASS: TestCalcAnchor/short (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807747+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807754+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_error_stack","Output":"    --- PASS: TestCalcAnchor/short_error_stack (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807757+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_error_stack","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807759+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_and_nolimit","Output":"    --- PASS: TestCalcAnchor/short_and_nolimit (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807762+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/short_and_nolimit","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807765+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/medium","Output":"    --- PASS: TestCalcAnchor/medium (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807768+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/medium","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.80777+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test_using_panic","Output":"    --- PASS: TestCalcAnchor/from_test_using_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807773+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test_using_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807775+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test","Output":"    --- PASS: TestCalcAnchor/from_test (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80778+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/from_test","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807783+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_panic","Output":"    --- PASS: TestCalcAnchor/macOS_from_test_using_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807786+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor/macOS_from_test_using_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807788+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestCalcAnchor","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807791+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit"}
+{"Time":"2022-08-09T20:26:30.807794+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit","Output":"=== RUN   TestStackPrint_limit\n"}
+{"Time":"2022-08-09T20:26:30.807796+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/short"}
+{"Time":"2022-08-09T20:26:30.807801+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/short","Output":"=== RUN   TestStackPrint_limit/short\n"}
+{"Time":"2022-08-09T20:26:30.807804+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium"}
+{"Time":"2022-08-09T20:26:30.807806+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium","Output":"=== RUN   TestStackPrint_limit/medium\n"}
+{"Time":"2022-08-09T20:26:30.807809+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_level_2"}
+{"Time":"2022-08-09T20:26:30.807813+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_level_2","Output":"=== RUN   TestStackPrint_limit/medium_level_2\n"}
+{"Time":"2022-08-09T20:26:30.807816+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_panic"}
+{"Time":"2022-08-09T20:26:30.807818+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_panic","Output":"=== RUN   TestStackPrint_limit/medium_panic\n"}
+{"Time":"2022-08-09T20:26:30.807826+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long"}
+{"Time":"2022-08-09T20:26:30.807829+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long","Output":"=== RUN   TestStackPrint_limit/long\n"}
+{"Time":"2022-08-09T20:26:30.807831+03:00","Action":"run","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long_lvl_2"}
+{"Time":"2022-08-09T20:26:30.807834+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long_lvl_2","Output":"=== RUN   TestStackPrint_limit/long_lvl_2\n"}
+{"Time":"2022-08-09T20:26:30.807837+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit","Output":"--- PASS: TestStackPrint_limit (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.80784+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/short","Output":"    --- PASS: TestStackPrint_limit/short (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807844+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/short","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807847+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium","Output":"    --- PASS: TestStackPrint_limit/medium (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807851+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807854+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_level_2","Output":"    --- PASS: TestStackPrint_limit/medium_level_2 (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807857+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_level_2","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807861+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_panic","Output":"    --- PASS: TestStackPrint_limit/medium_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807864+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/medium_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807866+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long","Output":"    --- PASS: TestStackPrint_limit/long (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807869+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807875+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long_lvl_2","Output":"    --- PASS: TestStackPrint_limit/long_lvl_2 (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.807878+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit/long_lvl_2","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807881+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Test":"TestStackPrint_limit","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.807883+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Output":"PASS\n"}
+{"Time":"2022-08-09T20:26:30.807886+03:00","Action":"output","Package":"github.com/lainio/err2/internal/debug","Output":"ok  \tgithub.com/lainio/err2/internal/debug\t(cached)\n"}
+{"Time":"2022-08-09T20:26:30.807893+03:00","Action":"pass","Package":"github.com/lainio/err2/internal/debug","Elapsed":0.001}
+{"Time":"2022-08-09T20:26:30.817542+03:00","Action":"run","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappens"}
+{"Time":"2022-08-09T20:26:30.817591+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappens","Output":"=== RUN   ExampleIs_errorHappens\n"}
+{"Time":"2022-08-09T20:26:30.817611+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappens","Output":"--- PASS: ExampleIs_errorHappens (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.817619+03:00","Action":"pass","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappens","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.817625+03:00","Action":"run","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappensNot"}
+{"Time":"2022-08-09T20:26:30.817628+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappensNot","Output":"=== RUN   ExampleIs_errorHappensNot\n"}
+{"Time":"2022-08-09T20:26:30.817632+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappensNot","Output":"--- PASS: ExampleIs_errorHappensNot (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.81764+03:00","Action":"pass","Package":"github.com/lainio/err2/try","Test":"ExampleIs_errorHappensNot","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.817644+03:00","Action":"run","Package":"github.com/lainio/err2/try","Test":"ExampleIsEOF1"}
+{"Time":"2022-08-09T20:26:30.817647+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIsEOF1","Output":"=== RUN   ExampleIsEOF1\n"}
+{"Time":"2022-08-09T20:26:30.817656+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"ExampleIsEOF1","Output":"--- PASS: ExampleIsEOF1 (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.817659+03:00","Action":"pass","Package":"github.com/lainio/err2/try","Test":"ExampleIsEOF1","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.817662+03:00","Action":"run","Package":"github.com/lainio/err2/try","Test":"Example_copyFile"}
+{"Time":"2022-08-09T20:26:30.817666+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"Example_copyFile","Output":"=== RUN   Example_copyFile\n"}
+{"Time":"2022-08-09T20:26:30.817673+03:00","Action":"output","Package":"github.com/lainio/err2/try","Test":"Example_copyFile","Output":"--- PASS: Example_copyFile (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.817676+03:00","Action":"pass","Package":"github.com/lainio/err2/try","Test":"Example_copyFile","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.817679+03:00","Action":"output","Package":"github.com/lainio/err2/try","Output":"PASS\n"}
+{"Time":"2022-08-09T20:26:30.817682+03:00","Action":"output","Package":"github.com/lainio/err2/try","Output":"ok  \tgithub.com/lainio/err2/try\t(cached)\n"}
+{"Time":"2022-08-09T20:26:30.817687+03:00","Action":"pass","Package":"github.com/lainio/err2/try","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819084+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestTry_noError"}
+{"Time":"2022-08-09T20:26:30.81912+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestTry_noError","Output":"=== RUN   TestTry_noError\n"}
+{"Time":"2022-08-09T20:26:30.819126+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestTry_noError","Output":"--- PASS: TestTry_noError (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819131+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestTry_noError","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819135+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestDefault_Error"}
+{"Time":"2022-08-09T20:26:30.819138+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestDefault_Error","Output":"=== RUN   TestDefault_Error\n"}
+{"Time":"2022-08-09T20:26:30.819141+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestDefault_Error","Output":"--- PASS: TestDefault_Error (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819144+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestDefault_Error","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819147+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestTry_Error"}
+{"Time":"2022-08-09T20:26:30.81915+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestTry_Error","Output":"=== RUN   TestTry_Error\n"}
+{"Time":"2022-08-09T20:26:30.819153+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestTry_Error","Output":"--- PASS: TestTry_Error (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819163+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestTry_Error","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819165+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll"}
+{"Time":"2022-08-09T20:26:30.819168+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll","Output":"=== RUN   TestPanickingCatchAll\n"}
+{"Time":"2022-08-09T20:26:30.819171+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/general_panic"}
+{"Time":"2022-08-09T20:26:30.819173+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/general_panic","Output":"=== RUN   TestPanickingCatchAll/general_panic\n"}
+{"Time":"2022-08-09T20:26:30.819179+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/runtime.error_panic"}
+{"Time":"2022-08-09T20:26:30.819182+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/runtime.error_panic","Output":"=== RUN   TestPanickingCatchAll/runtime.error_panic\n"}
+{"Time":"2022-08-09T20:26:30.819185+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll","Output":"--- PASS: TestPanickingCatchAll (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819188+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/general_panic","Output":"    --- PASS: TestPanickingCatchAll/general_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819191+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/general_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819194+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/runtime.error_panic","Output":"    --- PASS: TestPanickingCatchAll/runtime.error_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819198+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll/runtime.error_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819201+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchAll","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819203+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace"}
+{"Time":"2022-08-09T20:26:30.819206+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace","Output":"=== RUN   TestPanickingCatchTrace\n"}
+{"Time":"2022-08-09T20:26:30.81921+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic"}
+{"Time":"2022-08-09T20:26:30.819212+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"=== RUN   TestPanickingCatchTrace/general_panic\n"}
+{"Time":"2022-08-09T20:26:30.819215+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"---\n"}
+{"Time":"2022-08-09T20:26:30.819217+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"panic\n"}
+{"Time":"2022-08-09T20:26:30.81922+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"---\n"}
+{"Time":"2022-08-09T20:26:30.819222+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"goroutine 11 [running]:\n"}
+{"Time":"2022-08-09T20:26:30.819225+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"testing.tRunner(0x14000125d40, 0x14000061060)\n"}
+{"Time":"2022-08-09T20:26:30.819228+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"\t/opt/homebrew/Cellar/go/1.18/libexec/src/testing/testing.go:1439 +0x110\n"}
+{"Time":"2022-08-09T20:26:30.819237+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"created by testing.(*T).Run\n"}
+{"Time":"2022-08-09T20:26:30.819239+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"\t/opt/homebrew/Cellar/go/1.18/libexec/src/testing/testing.go:1486 +0x300\n"}
+{"Time":"2022-08-09T20:26:30.819242+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic"}
+{"Time":"2022-08-09T20:26:30.819245+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"=== RUN   TestPanickingCatchTrace/runtime.error_panic\n"}
+{"Time":"2022-08-09T20:26:30.819247+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"---\n"}
+{"Time":"2022-08-09T20:26:30.81925+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"runtime error: index out of range [0] with length 0\n"}
+{"Time":"2022-08-09T20:26:30.819252+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"---\n"}
+{"Time":"2022-08-09T20:26:30.819255+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"goroutine 12 [running]:\n"}
+{"Time":"2022-08-09T20:26:30.819258+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"testing.tRunner(0x14000176000, 0x14000061260)\n"}
+{"Time":"2022-08-09T20:26:30.81926+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"\t/opt/homebrew/Cellar/go/1.18/libexec/src/testing/testing.go:1439 +0x110\n"}
+{"Time":"2022-08-09T20:26:30.819263+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"created by testing.(*T).Run\n"}
+{"Time":"2022-08-09T20:26:30.819266+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"\t/opt/homebrew/Cellar/go/1.18/libexec/src/testing/testing.go:1486 +0x300\n"}
+{"Time":"2022-08-09T20:26:30.819269+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace","Output":"--- PASS: TestPanickingCatchTrace (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819271+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Output":"    --- PASS: TestPanickingCatchTrace/general_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819274+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/general_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819277+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Output":"    --- PASS: TestPanickingCatchTrace/runtime.error_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819279+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace/runtime.error_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819282+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCatchTrace","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819284+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle"}
+{"Time":"2022-08-09T20:26:30.819286+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle","Output":"=== RUN   TestPanickingCarryOn_Handle\n"}
+{"Time":"2022-08-09T20:26:30.81929+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/general_panic"}
+{"Time":"2022-08-09T20:26:30.819292+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/general_panic","Output":"=== RUN   TestPanickingCarryOn_Handle/general_panic\n"}
+{"Time":"2022-08-09T20:26:30.8193+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/runtime.error_panic"}
+{"Time":"2022-08-09T20:26:30.819302+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/runtime.error_panic","Output":"=== RUN   TestPanickingCarryOn_Handle/runtime.error_panic\n"}
+{"Time":"2022-08-09T20:26:30.819305+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle","Output":"--- PASS: TestPanickingCarryOn_Handle (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819308+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/general_panic","Output":"    --- PASS: TestPanickingCarryOn_Handle/general_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819311+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/general_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819313+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/runtime.error_panic","Output":"    --- PASS: TestPanickingCarryOn_Handle/runtime.error_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819316+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle/runtime.error_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819319+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanickingCarryOn_Handle","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819321+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Return"}
+{"Time":"2022-08-09T20:26:30.819323+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return","Output":"=== RUN   TestPanicking_Return\n"}
+{"Time":"2022-08-09T20:26:30.819326+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/general_panic"}
+{"Time":"2022-08-09T20:26:30.819328+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/general_panic","Output":"=== RUN   TestPanicking_Return/general_panic\n"}
+{"Time":"2022-08-09T20:26:30.819331+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/runtime.error_panic"}
+{"Time":"2022-08-09T20:26:30.819333+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/runtime.error_panic","Output":"=== RUN   TestPanicking_Return/runtime.error_panic\n"}
+{"Time":"2022-08-09T20:26:30.819336+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return","Output":"--- PASS: TestPanicking_Return (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819339+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/general_panic","Output":"    --- PASS: TestPanicking_Return/general_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819343+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/general_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819345+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/runtime.error_panic","Output":"    --- PASS: TestPanicking_Return/runtime.error_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819348+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Return/runtime.error_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.81935+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Return","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819352+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch"}
+{"Time":"2022-08-09T20:26:30.819355+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch","Output":"=== RUN   TestPanicking_Catch\n"}
+{"Time":"2022-08-09T20:26:30.819357+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/general_panic"}
+{"Time":"2022-08-09T20:26:30.819359+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/general_panic","Output":"=== RUN   TestPanicking_Catch/general_panic\n"}
+{"Time":"2022-08-09T20:26:30.819368+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/runtime.error_panic"}
+{"Time":"2022-08-09T20:26:30.81937+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/runtime.error_panic","Output":"=== RUN   TestPanicking_Catch/runtime.error_panic\n"}
+{"Time":"2022-08-09T20:26:30.819373+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch","Output":"--- PASS: TestPanicking_Catch (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819377+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/general_panic","Output":"    --- PASS: TestPanicking_Catch/general_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.81938+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/general_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819382+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/runtime.error_panic","Output":"    --- PASS: TestPanicking_Catch/runtime.error_panic (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819385+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch/runtime.error_panic","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819387+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestPanicking_Catch","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819389+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"TestCatch_Error"}
+{"Time":"2022-08-09T20:26:30.819392+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestCatch_Error","Output":"=== RUN   TestCatch_Error\n"}
+{"Time":"2022-08-09T20:26:30.819394+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"TestCatch_Error","Output":"--- PASS: TestCatch_Error (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819397+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"TestCatch_Error","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819399+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleFilterTry"}
+{"Time":"2022-08-09T20:26:30.819403+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleFilterTry","Output":"=== RUN   ExampleFilterTry\n"}
+{"Time":"2022-08-09T20:26:30.819406+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleFilterTry","Output":"--- PASS: ExampleFilterTry (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819408+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleFilterTry","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.81941+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleTryEOF"}
+{"Time":"2022-08-09T20:26:30.819412+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleTryEOF","Output":"=== RUN   ExampleTryEOF\n"}
+{"Time":"2022-08-09T20:26:30.819415+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleTryEOF","Output":"--- PASS: ExampleTryEOF (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819417+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleTryEOF","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.81942+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"Example_copyFile"}
+{"Time":"2022-08-09T20:26:30.819422+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"Example_copyFile","Output":"=== RUN   Example_copyFile\n"}
+{"Time":"2022-08-09T20:26:30.819425+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"Example_copyFile","Output":"--- PASS: Example_copyFile (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819427+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"Example_copyFile","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.81943+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleReturn"}
+{"Time":"2022-08-09T20:26:30.819432+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleReturn","Output":"=== RUN   ExampleReturn\n"}
+{"Time":"2022-08-09T20:26:30.819438+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleReturn","Output":"--- PASS: ExampleReturn (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819441+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleReturn","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819444+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleAnnotate"}
+{"Time":"2022-08-09T20:26:30.819446+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleAnnotate","Output":"=== RUN   ExampleAnnotate\n"}
+{"Time":"2022-08-09T20:26:30.819449+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleAnnotate","Output":"--- PASS: ExampleAnnotate (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819451+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleAnnotate","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819453+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleReturnf"}
+{"Time":"2022-08-09T20:26:30.819456+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleReturnf","Output":"=== RUN   ExampleReturnf\n"}
+{"Time":"2022-08-09T20:26:30.819458+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleReturnf","Output":"--- PASS: ExampleReturnf (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819461+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleReturnf","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819463+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleThrowf"}
+{"Time":"2022-08-09T20:26:30.819465+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleThrowf","Output":"=== RUN   ExampleThrowf\n"}
+{"Time":"2022-08-09T20:26:30.819468+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleThrowf","Output":"--- PASS: ExampleThrowf (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.81947+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleThrowf","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819473+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleAnnotate_deferStack"}
+{"Time":"2022-08-09T20:26:30.819475+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleAnnotate_deferStack","Output":"=== RUN   ExampleAnnotate_deferStack\n"}
+{"Time":"2022-08-09T20:26:30.819479+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleAnnotate_deferStack","Output":"--- PASS: ExampleAnnotate_deferStack (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819482+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleAnnotate_deferStack","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819484+03:00","Action":"run","Package":"github.com/lainio/err2","Test":"ExampleHandle"}
+{"Time":"2022-08-09T20:26:30.819486+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleHandle","Output":"=== RUN   ExampleHandle\n"}
+{"Time":"2022-08-09T20:26:30.819489+03:00","Action":"output","Package":"github.com/lainio/err2","Test":"ExampleHandle","Output":"--- PASS: ExampleHandle (0.00s)\n"}
+{"Time":"2022-08-09T20:26:30.819491+03:00","Action":"pass","Package":"github.com/lainio/err2","Test":"ExampleHandle","Elapsed":0}
+{"Time":"2022-08-09T20:26:30.819494+03:00","Action":"output","Package":"github.com/lainio/err2","Output":"PASS\n"}
+{"Time":"2022-08-09T20:26:30.819496+03:00","Action":"output","Package":"github.com/lainio/err2","Output":"ok  \tgithub.com/lainio/err2\t(cached)\n"}
+{"Time":"2022-08-09T20:26:30.819503+03:00","Action":"pass","Package":"github.com/lainio/err2","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016196+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_True"}
+{"Time":"2022-08-09T20:26:31.016237+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_True","Output":"=== RUN   ExampleAsserter_True\n"}
+{"Time":"2022-08-09T20:26:31.016266+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_True","Output":"--- PASS: ExampleAsserter_True (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.01628+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_True","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016285+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Truef"}
+{"Time":"2022-08-09T20:26:31.016289+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Truef","Output":"=== RUN   ExampleAsserter_Truef\n"}
+{"Time":"2022-08-09T20:26:31.016292+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Truef","Output":"--- PASS: ExampleAsserter_Truef (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016296+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Truef","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.0163+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Len"}
+{"Time":"2022-08-09T20:26:31.016305+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Len","Output":"=== RUN   ExampleAsserter_Len\n"}
+{"Time":"2022-08-09T20:26:31.016311+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Len","Output":"--- PASS: ExampleAsserter_Len (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016314+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Len","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016317+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_EqualInt"}
+{"Time":"2022-08-09T20:26:31.01632+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_EqualInt","Output":"=== RUN   ExampleAsserter_EqualInt\n"}
+{"Time":"2022-08-09T20:26:31.016324+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_EqualInt","Output":"--- PASS: ExampleAsserter_EqualInt (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016329+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_EqualInt","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016334+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil"}
+{"Time":"2022-08-09T20:26:31.016337+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"=== RUN   ExampleNotNil\n"}
+{"Time":"2022-08-09T20:26:31.016347+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"--- FAIL: ExampleNotNil (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016351+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.016354+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"sample: assert_test.go:64 ExampleNotNil.func1 assertion violation: pointer is nil\n"}
+{"Time":"2022-08-09T20:26:31.016359+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016362+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Output":"sample: assert_test.go:64 ExampleNotNil.func1 pointer is nil\n"}
+{"Time":"2022-08-09T20:26:31.016365+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleNotNil","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016368+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil"}
+{"Time":"2022-08-09T20:26:31.016371+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"=== RUN   ExampleMNotNil\n"}
+{"Time":"2022-08-09T20:26:31.016375+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"--- FAIL: ExampleMNotNil (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016378+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.016381+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"sample: assert_test.go:77 ExampleMNotNil.func1 assertion violation: map is nil\n"}
+{"Time":"2022-08-09T20:26:31.01639+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016393+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Output":"sample: assert_test.go:77 ExampleMNotNil.func1 map is nil\n"}
+{"Time":"2022-08-09T20:26:31.016396+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleMNotNil","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016399+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil"}
+{"Time":"2022-08-09T20:26:31.016402+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"=== RUN   ExampleCNotNil\n"}
+{"Time":"2022-08-09T20:26:31.016418+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"--- FAIL: ExampleCNotNil (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016422+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.016425+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"sample: assert_test.go:90 ExampleCNotNil.func1 assertion violation: channel is nil\n"}
+{"Time":"2022-08-09T20:26:31.016428+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016431+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Output":"sample: assert_test.go:90 ExampleCNotNil.func1 channel is nil\n"}
+{"Time":"2022-08-09T20:26:31.016435+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleCNotNil","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016438+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil"}
+{"Time":"2022-08-09T20:26:31.016441+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"=== RUN   ExampleSNotNil\n"}
+{"Time":"2022-08-09T20:26:31.016444+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"--- FAIL: ExampleSNotNil (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016448+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.01645+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"sample: assert_test.go:103 ExampleSNotNil.func1 assertion violation: slice is nil\n"}
+{"Time":"2022-08-09T20:26:31.016454+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016457+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Output":"sample: assert_test.go:103 ExampleSNotNil.func1 slice is nil\n"}
+{"Time":"2022-08-09T20:26:31.01646+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotNil","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016462+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual"}
+{"Time":"2022-08-09T20:26:31.016465+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"=== RUN   ExampleEqual\n"}
+{"Time":"2022-08-09T20:26:31.016486+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"--- FAIL: ExampleEqual (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016491+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.016494+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"sample: assert_test.go:116 ExampleEqual.func1 assertion violation: got 2, want 3\n"}
+{"Time":"2022-08-09T20:26:31.016506+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016509+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Output":"sample: assert_test.go:116 ExampleEqual.func1 got 2, want 3\n"}
+{"Time":"2022-08-09T20:26:31.016513+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleEqual","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016516+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen"}
+{"Time":"2022-08-09T20:26:31.016519+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"=== RUN   ExampleSLen\n"}
+{"Time":"2022-08-09T20:26:31.016523+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"--- FAIL: ExampleSLen (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016527+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.01653+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"sample: assert_test.go:128 ExampleSLen.func1 assertion violation: got 2, want 3\n"}
+{"Time":"2022-08-09T20:26:31.016533+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016536+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Output":"sample: assert_test.go:128 ExampleSLen.func1 got 2, want 3\n"}
+{"Time":"2022-08-09T20:26:31.016539+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleSLen","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016542+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Lenf"}
+{"Time":"2022-08-09T20:26:31.016544+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Lenf","Output":"=== RUN   ExampleAsserter_Lenf\n"}
+{"Time":"2022-08-09T20:26:31.016554+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Lenf","Output":"--- PASS: ExampleAsserter_Lenf (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016558+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Lenf","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016561+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Empty"}
+{"Time":"2022-08-09T20:26:31.016574+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Empty","Output":"=== RUN   ExampleAsserter_Empty\n"}
+{"Time":"2022-08-09T20:26:31.016579+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Empty","Output":"--- PASS: ExampleAsserter_Empty (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016582+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_Empty","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016585+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_NoImplementation"}
+{"Time":"2022-08-09T20:26:31.016588+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_NoImplementation","Output":"=== RUN   ExampleAsserter_NoImplementation\n"}
+{"Time":"2022-08-09T20:26:31.016592+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_NoImplementation","Output":"--- PASS: ExampleAsserter_NoImplementation (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016595+03:00","Action":"pass","Package":"github.com/lainio/err2/assert","Test":"ExampleAsserter_NoImplementation","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016599+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty"}
+{"Time":"2022-08-09T20:26:31.016601+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"=== RUN   ExampleSNotEmpty\n"}
+{"Time":"2022-08-09T20:26:31.016616+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"--- FAIL: ExampleSNotEmpty (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016626+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.01663+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"sample: assert_test.go:181 ExampleSNotEmpty.func1 assertion violation: slice shouldn't be empty\n"}
+{"Time":"2022-08-09T20:26:31.016636+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016639+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Output":"sample: assert_test.go:181 ExampleSNotEmpty.func1 slice shouldn't be empty\n"}
+{"Time":"2022-08-09T20:26:31.016643+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleSNotEmpty","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016646+03:00","Action":"run","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty"}
+{"Time":"2022-08-09T20:26:31.016654+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"=== RUN   ExampleNotEmpty\n"}
+{"Time":"2022-08-09T20:26:31.016659+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"--- FAIL: ExampleNotEmpty (0.00s)\n"}
+{"Time":"2022-08-09T20:26:31.016673+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"got:\n"}
+{"Time":"2022-08-09T20:26:31.016677+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"sample: assert_test.go:193 ExampleNotEmpty.func1 assertion violation: string shouldn't be empty\n"}
+{"Time":"2022-08-09T20:26:31.01668+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"want:\n"}
+{"Time":"2022-08-09T20:26:31.016684+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Output":"sample: assert_test.go:193 ExampleNotEmpty.func1 string shouldn't be empty\n"}
+{"Time":"2022-08-09T20:26:31.016687+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Test":"ExampleNotEmpty","Elapsed":0}
+{"Time":"2022-08-09T20:26:31.016689+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Output":"FAIL\n"}
+{"Time":"2022-08-09T20:26:31.016988+03:00","Action":"output","Package":"github.com/lainio/err2/assert","Output":"FAIL\tgithub.com/lainio/err2/assert\t0.124s\n"}
+{"Time":"2022-08-09T20:26:31.017041+03:00","Action":"fail","Package":"github.com/lainio/err2/assert","Elapsed":0.125}
+{"Time":"2022-08-09T20:26:31.017566+03:00","Action":"output","Package":"github.com/lainio/err2/internal/handler","Output":"?   \tgithub.com/lainio/err2/internal/handler\t[no test files]\n"}
+{"Time":"2022-08-09T20:26:31.017577+03:00","Action":"skip","Package":"github.com/lainio/err2/internal/handler","Elapsed":0}

--- a/test/fixtures/test/fail_include_sub_tests.json
+++ b/test/fixtures/test/fail_include_sub_tests.json
@@ -1,0 +1,45 @@
+{"Time":"2022-08-09T12:53:10.513445+03:00","Action":"run","Package":"test","Test":"TestHello"}
+{"Time":"2022-08-09T12:53:10.513809+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"=== RUN   TestHello\n"}
+{"Time":"2022-08-09T12:53:10.51382+03:00","Action":"run","Package":"test","Test":"TestHello/first"}
+{"Time":"2022-08-09T12:53:10.513831+03:00","Action":"output","Package":"test","Test":"TestHello/first","Output":"=== RUN   TestHello/first\n"}
+{"Time":"2022-08-09T12:53:10.513846+03:00","Action":"output","Package":"test","Test":"TestHello/first","Output":"    test_test.go:20: simulate test fail\n"}
+{"Time":"2022-08-09T12:53:10.513862+03:00","Action":"run","Package":"test","Test":"TestHello/second"}
+{"Time":"2022-08-09T12:53:10.513867+03:00","Action":"output","Package":"test","Test":"TestHello/second","Output":"=== RUN   TestHello/second\n"}
+{"Time":"2022-08-09T12:53:10.513873+03:00","Action":"output","Package":"test","Test":"TestHello/second","Output":"    test_test.go:20: simulate test fail\n"}
+{"Time":"2022-08-09T12:53:10.513878+03:00","Action":"run","Package":"test","Test":"TestHello/name_1"}
+{"Time":"2022-08-09T12:53:10.513883+03:00","Action":"output","Package":"test","Test":"TestHello/name_1","Output":"=== RUN   TestHello/name_1\n"}
+{"Time":"2022-08-09T12:53:10.513888+03:00","Action":"output","Package":"test","Test":"TestHello/name_1","Output":"    test_test.go:20: simulate test fail\n"}
+{"Time":"2022-08-09T12:53:10.513893+03:00","Action":"run","Package":"test","Test":"TestHello/name_2"}
+{"Time":"2022-08-09T12:53:10.513898+03:00","Action":"output","Package":"test","Test":"TestHello/name_2","Output":"=== RUN   TestHello/name_2\n"}
+{"Time":"2022-08-09T12:53:10.513903+03:00","Action":"output","Package":"test","Test":"TestHello/name_2","Output":"    test_test.go:20: simulate test fail\n"}
+{"Time":"2022-08-09T12:53:10.513907+03:00","Action":"run","Package":"test","Test":"TestHello/name_3"}
+{"Time":"2022-08-09T12:53:10.513912+03:00","Action":"output","Package":"test","Test":"TestHello/name_3","Output":"=== RUN   TestHello/name_3\n"}
+{"Time":"2022-08-09T12:53:10.513917+03:00","Action":"output","Package":"test","Test":"TestHello/name_3","Output":"    test_test.go:20: simulate test fail\n"}
+{"Time":"2022-08-09T12:53:10.513922+03:00","Action":"cont","Package":"test","Test":"TestHello"}
+{"Time":"2022-08-09T12:53:10.513926+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"=== CONT  TestHello\n"}
+{"Time":"2022-08-09T12:53:10.513931+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"    test_test.go:24: world\n"}
+{"Time":"2022-08-09T12:53:10.513938+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"--- FAIL: TestHello (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.513943+03:00","Action":"output","Package":"test","Test":"TestHello/first","Output":"    --- FAIL: TestHello/first (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.513948+03:00","Action":"fail","Package":"test","Test":"TestHello/first","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.513971+03:00","Action":"output","Package":"test","Test":"TestHello/second","Output":"    --- FAIL: TestHello/second (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.513976+03:00","Action":"fail","Package":"test","Test":"TestHello/second","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.513981+03:00","Action":"output","Package":"test","Test":"TestHello/name_1","Output":"    --- FAIL: TestHello/name_1 (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.513986+03:00","Action":"fail","Package":"test","Test":"TestHello/name_1","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.513991+03:00","Action":"output","Package":"test","Test":"TestHello/name_2","Output":"    --- FAIL: TestHello/name_2 (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.513996+03:00","Action":"fail","Package":"test","Test":"TestHello/name_2","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.514+03:00","Action":"output","Package":"test","Test":"TestHello/name_3","Output":"    --- FAIL: TestHello/name_3 (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.514005+03:00","Action":"fail","Package":"test","Test":"TestHello/name_3","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.514021+03:00","Action":"fail","Package":"test","Test":"TestHello","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.514024+03:00","Action":"run","Package":"test","Test":"TestHello2"}
+{"Time":"2022-08-09T12:53:10.514027+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"=== RUN   TestHello2\n"}
+{"Time":"2022-08-09T12:53:10.51403+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"    test_test.go:28: world\n"}
+{"Time":"2022-08-09T12:53:10.514034+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"--- PASS: TestHello2 (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.514037+03:00","Action":"pass","Package":"test","Test":"TestHello2","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.51404+03:00","Action":"run","Package":"test","Test":"TestWithEnv"}
+{"Time":"2022-08-09T12:53:10.514043+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"=== RUN   TestWithEnv\n"}
+{"Time":"2022-08-09T12:53:10.514047+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"    test_test.go:32: \n"}
+{"Time":"2022-08-09T12:53:10.51405+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"--- PASS: TestWithEnv (0.00s)\n"}
+{"Time":"2022-08-09T12:53:10.514053+03:00","Action":"pass","Package":"test","Test":"TestWithEnv","Elapsed":0}
+{"Time":"2022-08-09T12:53:10.514056+03:00","Action":"output","Package":"test","Output":"FAIL\n"}
+{"Time":"2022-08-09T12:53:10.514101+03:00","Action":"output","Package":"test","Output":"FAIL\ttest\t0.127s\n"}
+{"Time":"2022-08-09T12:53:10.514107+03:00","Action":"fail","Package":"test","Elapsed":0.127}

--- a/test/fixtures/test/fail_test.json
+++ b/test/fixtures/test/fail_test.json
@@ -1,0 +1,64 @@
+{"Time":"2022-07-16T13:31:03.420632+03:00","Action":"output","Package":"test","Output":"?   \tgithub.com/lainio/ic\t[no test files]\n"}
+{"Time":"2022-07-16T13:31:03.420838+03:00","Action":"skip","Package":"test","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431083+03:00","Action":"run","Package":"test","Test":"TestNewChain"}
+{"Time":"2022-07-16T13:31:03.431116+03:00","Action":"output","Package":"test","Test":"TestNewChain","Output":"=== RUN   TestNewChain\n"}
+{"Time":"2022-07-16T13:31:03.431137+03:00","Action":"output","Package":"test","Test":"TestNewChain","Output":"--- PASS: TestNewChain (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431143+03:00","Action":"pass","Package":"test","Test":"TestNewChain","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431149+03:00","Action":"run","Package":"test","Test":"TestRead"}
+{"Time":"2022-07-16T13:31:03.431153+03:00","Action":"output","Package":"test","Test":"TestRead","Output":"=== RUN   TestRead\n"}
+{"Time":"2022-07-16T13:31:03.431158+03:00","Action":"output","Package":"test","Test":"TestRead","Output":"--- PASS: TestRead (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431162+03:00","Action":"pass","Package":"test","Test":"TestRead","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431172+03:00","Action":"run","Package":"test","Test":"TestVerifyChainFail"}
+{"Time":"2022-07-16T13:31:03.431176+03:00","Action":"output","Package":"test","Test":"TestVerifyChainFail","Output":"=== RUN   TestVerifyChainFail\n"}
+{"Time":"2022-07-16T13:31:03.431181+03:00","Action":"output","Package":"test","Test":"TestVerifyChainFail","Output":"--- PASS: TestVerifyChainFail (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431188+03:00","Action":"pass","Package":"test","Test":"TestVerifyChainFail","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431192+03:00","Action":"run","Package":"test","Test":"TestVerifyChain"}
+{"Time":"2022-07-16T13:31:03.431196+03:00","Action":"output","Package":"test","Test":"TestVerifyChain","Output":"=== RUN   TestVerifyChain\n"}
+{"Time":"2022-07-16T13:31:03.431201+03:00","Action":"output","Package":"test","Test":"TestVerifyChain","Output":"--- PASS: TestVerifyChain (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431205+03:00","Action":"pass","Package":"test","Test":"TestVerifyChain","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431209+03:00","Action":"run","Package":"test","Test":"TestInvitation"}
+{"Time":"2022-07-16T13:31:03.431212+03:00","Action":"output","Package":"test","Test":"TestInvitation","Output":"=== RUN   TestInvitation\n"}
+{"Time":"2022-07-16T13:31:03.431217+03:00","Action":"output","Package":"test","Test":"TestInvitation","Output":"--- PASS: TestInvitation (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431221+03:00","Action":"pass","Package":"test","Test":"TestInvitation","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431225+03:00","Action":"run","Package":"test","Test":"TestCommonInviter"}
+{"Time":"2022-07-16T13:31:03.431228+03:00","Action":"output","Package":"test","Test":"TestCommonInviter","Output":"=== RUN   TestCommonInviter\n"}
+{"Time":"2022-07-16T13:31:03.431232+03:00","Action":"output","Package":"test","Test":"TestCommonInviter","Output":"--- PASS: TestCommonInviter (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431243+03:00","Action":"pass","Package":"test","Test":"TestCommonInviter","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431247+03:00","Action":"run","Package":"test","Test":"TestSameInviter"}
+{"Time":"2022-07-16T13:31:03.431251+03:00","Action":"output","Package":"test","Test":"TestSameInviter","Output":"=== RUN   TestSameInviter\n"}
+{"Time":"2022-07-16T13:31:03.43127+03:00","Action":"output","Package":"test","Test":"TestSameInviter","Output":"--- PASS: TestSameInviter (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431274+03:00","Action":"pass","Package":"test","Test":"TestSameInviter","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431276+03:00","Action":"run","Package":"test","Test":"TestHops"}
+{"Time":"2022-07-16T13:31:03.431279+03:00","Action":"output","Package":"test","Test":"TestHops","Output":"=== RUN   TestHops\n"}
+{"Time":"2022-07-16T13:31:03.431282+03:00","Action":"output","Package":"test","Test":"TestHops","Output":"--- PASS: TestHops (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431285+03:00","Action":"pass","Package":"test","Test":"TestHops","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431287+03:00","Action":"run","Package":"test","Test":"TestChallengeInvitee"}
+{"Time":"2022-07-16T13:31:03.43129+03:00","Action":"output","Package":"test","Test":"TestChallengeInvitee","Output":"=== RUN   TestChallengeInvitee\n"}
+{"Time":"2022-07-16T13:31:03.431293+03:00","Action":"output","Package":"test","Test":"TestChallengeInvitee","Output":"--- PASS: TestChallengeInvitee (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.431295+03:00","Action":"pass","Package":"test","Test":"TestChallengeInvitee","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431298+03:00","Action":"output","Package":"test","Output":"PASS\n"}
+{"Time":"2022-07-16T13:31:03.431301+03:00","Action":"output","Package":"test","Output":"ok  \tgithub.com/lainio/ic/chain\t(cached)\n"}
+{"Time":"2022-07-16T13:31:03.431307+03:00","Action":"pass","Package":"test","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.431521+03:00","Action":"output","Package":"test","Output":"?   \tgithub.com/lainio/ic/crypto\t[no test files]\n"}
+{"Time":"2022-07-16T13:31:03.431526+03:00","Action":"skip","Package":"test","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.612405+03:00","Action":"run","Package":"test","Test":"TestNewRootNode"}
+{"Time":"2022-07-16T13:31:03.612451+03:00","Action":"output","Package":"test","Test":"TestNewRootNode","Output":"=== RUN   TestNewRootNode\n"}
+{"Time":"2022-07-16T13:31:03.612525+03:00","Action":"output","Package":"test","Test":"TestNewRootNode","Output":"    node_test.go:52: got 1, want 0\n"}
+{"Time":"2022-07-16T13:31:03.612525+03:00","Action":"output","Package":"test","Test":"TestNewRootNode","Output":"    node_test.go:56: got 1, want 0\n"}
+{"Time":"2022-07-16T13:31:03.612537+03:00","Action":"output","Package":"test","Test":"TestNewRootNode","Output":"--- FAIL: TestNewRootNode (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.612542+03:00","Action":"fail","Package":"test","Test":"TestNewRootNode","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.612548+03:00","Action":"run","Package":"test","Test":"TestInvite"}
+{"Time":"2022-07-16T13:31:03.612552+03:00","Action":"output","Package":"test","Test":"TestInvite","Output":"=== RUN   TestInvite\n"}
+{"Time":"2022-07-16T13:31:03.614851+03:00","Action":"output","Package":"test","Test":"TestInvite","Output":"--- PASS: TestInvite (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.614859+03:00","Action":"pass","Package":"test","Test":"TestInvite","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.614864+03:00","Action":"run","Package":"test","Test":"TestCommonChains"}
+{"Time":"2022-07-16T13:31:03.614867+03:00","Action":"output","Package":"test","Test":"TestCommonChains","Output":"=== RUN   TestCommonChains\n"}
+{"Time":"2022-07-16T13:31:03.615324+03:00","Action":"output","Package":"test","Test":"TestCommonChains","Output":"--- PASS: TestCommonChains (0.00s)\n"}
+{"Time":"2022-07-16T13:31:03.615331+03:00","Action":"pass","Package":"test","Test":"TestCommonChains","Elapsed":0}
+{"Time":"2022-07-16T13:31:03.615336+03:00","Action":"run","Package":"test","Test":"TestWebOfTrustInfo"}
+{"Time":"2022-07-16T13:31:03.615351+03:00","Action":"output","Package":"test","Test":"TestWebOfTrustInfo","Output":"=== RUN   TestWebOfTrustInfo\n"}
+{"Time":"2022-07-16T13:31:03.625008+03:00","Action":"output","Package":"test","Test":"TestWebOfTrustInfo","Output":"--- PASS: TestWebOfTrustInfo (0.01s)\n"}
+{"Time":"2022-07-16T13:31:03.62502+03:00","Action":"pass","Package":"test","Test":"TestWebOfTrustInfo","Elapsed":0.01}
+{"Time":"2022-07-16T13:31:03.625027+03:00","Action":"output","Package":"test","Output":"FAIL\n"}
+{"Time":"2022-07-16T13:31:03.625334+03:00","Action":"output","Package":"test","Output":"FAIL\tgithub.com/lainio/ic/node\t0.112s\n"}
+{"Time":"2022-07-16T13:31:03.625352+03:00","Action":"fail","Package":"test","Elapsed":0.112}

--- a/test/fixtures/test/pass_test.json
+++ b/test/fixtures/test/pass_test.json
@@ -1,0 +1,18 @@
+{"Time":"2022-08-08T18:27:19.207877+03:00","Action":"run","Package":"test","Test":"TestHello"}
+{"Time":"2022-08-08T18:27:19.20799+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"=== RUN   TestHello\n"}
+{"Time":"2022-08-08T18:27:19.207998+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"    test_test.go:9: world\n"}
+{"Time":"2022-08-08T18:27:19.208005+03:00","Action":"output","Package":"test","Test":"TestHello","Output":"--- PASS: TestHello (0.00s)\n"}
+{"Time":"2022-08-08T18:27:19.20801+03:00","Action":"pass","Package":"test","Test":"TestHello","Elapsed":0}
+{"Time":"2022-08-08T18:27:19.208016+03:00","Action":"run","Package":"test","Test":"TestHello2"}
+{"Time":"2022-08-08T18:27:19.20802+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"=== RUN   TestHello2\n"}
+{"Time":"2022-08-08T18:27:19.208024+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"    test_test.go:13: world\n"}
+{"Time":"2022-08-08T18:27:19.208028+03:00","Action":"output","Package":"test","Test":"TestHello2","Output":"--- PASS: TestHello2 (0.00s)\n"}
+{"Time":"2022-08-08T18:27:19.208032+03:00","Action":"pass","Package":"test","Test":"TestHello2","Elapsed":0}
+{"Time":"2022-08-08T18:27:19.208036+03:00","Action":"run","Package":"test","Test":"TestWithEnv"}
+{"Time":"2022-08-08T18:27:19.20804+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"=== RUN   TestWithEnv\n"}
+{"Time":"2022-08-08T18:27:19.208044+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"    test_test.go:17: \n"}
+{"Time":"2022-08-08T18:27:19.208049+03:00","Action":"output","Package":"test","Test":"TestWithEnv","Output":"--- PASS: TestWithEnv (0.00s)\n"}
+{"Time":"2022-08-08T18:27:19.208052+03:00","Action":"pass","Package":"test","Test":"TestWithEnv","Elapsed":0}
+{"Time":"2022-08-08T18:27:19.208056+03:00","Action":"output","Package":"test","Output":"PASS\n"}
+{"Time":"2022-08-08T18:27:19.208061+03:00","Action":"output","Package":"test","Output":"ok  \ttest\t(cached)\n"}
+{"Time":"2022-08-08T18:27:19.208069+03:00","Action":"pass","Package":"test","Elapsed":0}


### PR DESCRIPTION
- using `go test -json` output format to fill vim's location list asynchronously
- unit tests for relative path calculation, package root calculation, and a few JSON outputs to test the actual parsing
- fixing situations where sub-tests weren't run (Go's table test cases)
- integrated into the current notification system
- small updates to the current documentation
- future todo: maybe separate use of `-json` to dedicated flag, etc.