### PR TITLE
auto format on save for all changed files

### DIFF
--- a/after/ftplugin/go.lua
+++ b/after/ftplugin/go.lua
@@ -183,7 +183,7 @@ vim.api.nvim_clear_autocmds({
 if opt.auto_format then
     vim.api.nvim_create_autocmd({ 'BufWritePre' }, {
         group = group,
-        pattern = '<buffer>',
+        pattern =  '*.go',
         command = 'GoFormat',
     })
 end


### PR DESCRIPTION
#### Current behaviour

Auto format function only formats the current buffer file even if there are multiple changed go files. It could be confusing when doing `:wall`.

#### Changed behaviour

Auto format function formats all changed files.

#### Known issue

neovim is having [issue detecting changed buffers](https://github.com/neovim/neovim/issues/2127). The below script could fix but it's probably out this plugin's scope.
```
augroup checktime
    autocmd!
    if !has("gui_running")
        "silent! necessary otherwise throws errors when using command
        "line window.
        autocmd BufEnter,FocusGained,BufEnter,FocusLost,WinLeave * checktime
    endif
augroup END
```