### PR TITLE
fix: avoid data race between formatter and Neovim

### DIFF
--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -48,7 +48,7 @@ local function do_fmt(formatter, args)
     local original_line = vim.fn.getline('.')
     local original_col_nr = vim.fn.col('.')
     local cmd = system.wrap_file_command(formatter, args, file_path)
-    vim.fn.jobstart(cmd, {
+    local job_id = vim.fn.jobstart(cmd, {
         on_exit = function(_, code, _)
             if code == 0 then
                 output.show_success('GoFormat', 'Success')
@@ -72,6 +72,8 @@ local function do_fmt(formatter, args)
             output.show_error('GoFormat', results)
         end,
     })
+    -- wait for the job so we don't race nvim writing out the buffer
+    vim.fn.jobwait({job_id})
 end
 
 function M.lsp()


### PR DESCRIPTION
By default, nvim-go auto-formats on save. Occasionally when saving, goimports returns a "no such file" error. This seems to be caused by a race between the format job, and Neovim writing out the file.

By running the formatting job synchronously this race is avoided.

Here's the bug I see during write that this change fixes:

![screenshot_2024-01-12-001917](https://github.com/crispgm/nvim-go/assets/861778/88b5b8bc-e5bb-443a-8bab-70d33e8a08ad)
