### PR TITLE
feat: only check auto-determined func name

### DIFF
--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -156,19 +156,20 @@ function M.test_func(opt)
         end
         local cur_line = vim.fn.getline(line)
         func_name = split_file_name(cur_line)
-    end
-    if not valid_func_name(func_name) then
-        output.show_error(
-            'GoTestFunc',
-            string.format('Invalid test func: %s', func_name)
-        )
-        return
+        if not valid_func_name(func_name) then
+            output.show_error(
+                'GoTestFunc',
+                string.format('Invalid test func: %s', func_name)
+            )
+            return
+        end
+        func_name = vim.fn.shellescape(string.format('^%s$', func_name))
     end
     local cmd = {
         'go',
         'test',
         '-run',
-        vim.fn.shellescape(string.format('^%s$', func_name)),
+        func_name,
     }
     do_test(prefix, build_args(cmd))
 end


### PR DESCRIPTION
Rationale is that the user is able to provide their own value for `func_name` in `opt.func` and thus should be fully responsible to provide a valid name.

This allows e.g. to provide a specific sub-test-name for table-driven tests.