### PR TITLE
feat: allow specifying cwd for test_all()

### DIFF
--- a/lua/go/format.lua
+++ b/lua/go/format.lua
@@ -48,7 +48,7 @@ local function do_fmt(formatter, args)
     local original_line = vim.fn.getline('.')
     local original_col_nr = vim.fn.col('.')
     local cmd = system.wrap_file_command(formatter, args, file_path)
-    vim.fn.jobstart(cmd, {
+    local job_id = vim.fn.jobstart(cmd, {
         on_exit = function(_, code, _)
             if code == 0 then
                 output.show_success('GoFormat', 'Success')
@@ -72,6 +72,8 @@ local function do_fmt(formatter, args)
             output.show_error('GoFormat', results)
         end,
     })
+    -- wait for the job so we don't race nvim writing out the buffer
+    vim.fn.jobwait({job_id})
 end
 
 function M.lsp()

--- a/lua/go/test.lua
+++ b/lua/go/test.lua
@@ -52,7 +52,7 @@ local function valid_buf()
     return false
 end
 
-local function do_test(prefix, cmd)
+local function do_test(prefix, cmd, cwd)
     if not valid_buf() then
         return
     end
@@ -92,7 +92,7 @@ local function do_test(prefix, cmd)
         end
     end
 
-    local cwd = vim.fn.expand('%:p:h')
+    cwd = cwd or vim.fn.expand('%:p:h')
     local env = config.options.test_env
     local opts = {
         on_exit = function(_, code, _)
@@ -125,14 +125,14 @@ function M.test()
     do_test(prefix, build_args(cmd))
 end
 
-function M.test_all()
+function M.test_all(cwd)
     if not util.binary_exists('go') then
         return
     end
 
     local prefix = 'GoTestAll'
     local cmd = { 'go', 'test', './...' }
-    do_test(prefix, build_args(cmd))
+    do_test(prefix, build_args(cmd), cwd)
 end
 
 function M.test_func(opt)


### PR DESCRIPTION
Especially for running all tests it can be interesting to specify the `cwd` so you can e.g. pickup really all tests in a multi-module repo.