### PR TITLE
add 'GoMod' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Neovim (from v0.5) embeds a built-in Language Server Protocol (LSP) client. And 
 - Modify struct tags with `:GoAddTags`, `:GoRemoveTags`, `:GoClearTags`, `:GoAddTagOptions`, `:GoRemoveTagOptions` and `:GoClearTagOptions`.
 - Generates JSON models with `:GoQuickType` (via `quicktype`).
 - Generate if err based on function return values with `:GoIfErr` (via `iferr`).
+- Run `go mod` command with `:GoMod`.
 
 [Screenshots](https://github.com/crispgm/nvim-go/wiki#screenshots)
 

--- a/lua/go/mod.lua
+++ b/lua/go/mod.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+local vim = vim
+local util = require('go.util')
+
+local function do_mod(args)
+    if not util.binary_exists('go') then
+        return
+    end
+    vim.api.nvim_command('!go mod ' .. args)
+end
+
+function M.mod(fargs)
+    do_mod(table.concat(fargs, ' '))
+end
+
+return M

--- a/plugin/go.lua
+++ b/plugin/go.lua
@@ -14,3 +14,9 @@ vim.api.nvim_create_user_command('GoUpdateBinaries', function(_)
 end, {
     nargs = 0,
 })
+
+vim.api.nvim_create_user_command('GoMod', function(opts)
+    require('go.mod').mod(opts.fargs)
+end, {
+    nargs = '+',
+})


### PR DESCRIPTION
This PR adds new neovim user command `GoMod` to run `go mod` command (e.g. `GoMod tidy` runs `go mod tidy`).