### PR TITLE
fix: Fix healthcheck using deprecated functions

### DIFF
--- a/lua/go/health.lua
+++ b/lua/go/health.lua
@@ -3,24 +3,31 @@ local M = {}
 local health = vim.health or require('health')
 local tools = require('go.config').tools
 
+-- The "report_" prefix is deprecated and will be removed in 0.11. If the
+-- replacements are available, we want to use those instead.
+local report_start = health.start or health.report_start
+local report_ok = health.ok or health.report_ok
+local report_error = health.error or health.report_error
+local report_info = health.info or health.report_info
+
 function M.check()
-    health.report_start('Binaries')
+    report_start('Binaries')
     local any_err = true
     if vim.fn.executable('go') == 1 then
-        health.report_info('Go installed.')
+        report_info('Go installed.')
     else
-        health.report_error('Go is not installed.')
+        report_error('Go is not installed.')
         any_err = false
     end
     for _, val in ipairs(tools) do
         if vim.fn.executable(val.name) == 1 then
-            health.report_info('Tool installed: ' .. val.name)
+            report_info('Tool installed: ' .. val.name)
         else
-            health.report_error('Missing tool: ' .. val.name)
+            report_error('Missing tool: ' .. val.name)
         end
     end
     if any_err then
-        health.report_ok('No issues found')
+        report_ok('No issues found')
     end
 end
 


### PR DESCRIPTION
### Description

This fixes `:checkhealth` from showing deprecation warnings in 0.10.0+.

In neovim 0.10, the `vim.health.report_*` functions were deprecated. It is recommended to use the new functions which use the same name without the `report_` prefix (i.e. `vim.health.start`, `vim.health.ok`, etc). The deprecated functions will be removed in 0.11.

### Testing

I just set up a minimal config that loads my local version of the plugin. Then I used `bob` to switch between versions to test from 0.7 to 0.10

```lua
vim.opt.runtimepath:prepend("~/src/nvim-go")
```

This is what the current `main` branch shows on 0.10.0 before any fixes. There are also additional warnings and stack traces in `:messages`.

```
go: require("go.health").check()

- WARNING vim.health.report_start() is deprecated, use vim.health.start() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11

Binaries ~
- WARNING vim.health.report_info() is deprecated, use vim.health.info() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11
- Go installed.
- Tool installed: gopls
- Tool installed: golint
- Tool installed: revive
- Tool installed: goimports
- Tool installed: gofumpt
- Tool installed: errcheck
- Tool installed: staticcheck
- Tool installed: golangci-lint
- Tool installed: gomodifytags
- Tool installed: quicktype
- Tool installed: gotests
- Tool installed: iferr
- WARNING vim.health.report_ok() is deprecated, use vim.health.ok() instead. :help |deprecated|
  Feature will be removed in Nvim 0.11
- OK No issues found
```

I then tested the changes on 0.10.0, 0.9.0, 0.8.0, and 0.7.2 (that's the first release with a mac binary that supports ARM) since the project's readme mentions working on version >= 0.7. There are no more deprecation warnings and no more warnings in `:messages`

```
go: require("go.health").check()

Binaries ~
- Go installed.
- Tool installed: gopls
- Tool installed: golint
- Tool installed: revive
- Tool installed: goimports
- Tool installed: gofumpt
- Tool installed: errcheck
- Tool installed: staticcheck
- Tool installed: golangci-lint
- Tool installed: gomodifytags
- Tool installed: quicktype
- Tool installed: gotests
- Tool installed: iferr
- OK No issues found
```
