### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/lua/go/config.lua
+++ b/lua/go/config.lua
@@ -49,7 +49,7 @@ M.tools = {
     { name = 'staticcheck', src = 'honnef.co/go/tools/cmd/staticcheck' },
     {
         name = 'golangci-lint',
-        src = 'github.com/golangci/golangci-lint/cmd/golangci-lint',
+        src = 'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
     },
     { name = 'gomodifytags', src = 'github.com/fatih/gomodifytags' },
     { name = 'quicktype', src = 'quicktype', pkg_mgr = 'npm' },

--- a/lua/go/lint.lua
+++ b/lua/go/lint.lua
@@ -150,6 +150,12 @@ local function do_lint(linter, args)
 end
 
 function M.golangci_lint()
+    if util.binary_exists('golangci-lint') then
+        local status = vim.system({'golangci-lint', 'version', '--short'}):wait()
+        if status.code ~= 0 or string.sub(status.stdout,1,2) ~= "v2" then
+            output.show_warning('GoLint', 'Incompatible golangci-lint version. Try running \'GoUpdateBinaries\'.')
+        end
+    end
     do_lint('golangci-lint', {
         'run',
         '--output.text.colors=false',

--- a/lua/go/lint.lua
+++ b/lua/go/lint.lua
@@ -151,9 +151,10 @@ end
 
 function M.golangci_lint()
     do_lint('golangci-lint', {
-        '--out-format=line-number',
-        '--print-issued-lines=false',
         'run',
+        '--output.text.colors=false',
+        '--output.text.print-issued-lines=false',
+        '--show-stats=false',
     })
 end
 

--- a/lua/go/lint.lua
+++ b/lua/go/lint.lua
@@ -154,6 +154,7 @@ function M.golangci_lint()
         local status = vim.system({'golangci-lint', 'version', '--short'}):wait()
         if status.code ~= 0 or string.sub(status.stdout,1,2) ~= "v2" then
             output.show_warning('GoLint', 'Incompatible golangci-lint version. Try running \'GoUpdateBinaries\'.')
+            return
         end
     end
     do_lint('golangci-lint', {


### PR DESCRIPTION
* Use the v2 import path for installation of the binary.
* Update the arguments passed by nvim-go for v2 compatibility.

Closes: #72