### PR TITLE
fix: support offical binaries of golangci-lint

### DIFF
--- a/lua/go/lint.lua
+++ b/lua/go/lint.lua
@@ -152,7 +152,8 @@ end
 function M.golangci_lint()
     if util.binary_exists('golangci-lint') then
         local status = vim.system({'golangci-lint', 'version', '--short'}):wait()
-        if status.code ~= 0 or string.sub(status.stdout,1,2) ~= "v2" then
+        if status.code ~= 0 or
+            (string.sub(status.stdout,1,2) ~= "v2" and string.sub(status.stdout,1,1) ~= "2") then
             output.show_warning('GoLint', 'Incompatible golangci-lint version. Try running \'GoUpdateBinaries\'.')
             return
         end


### PR DESCRIPTION
Upstream uses Goreleaser to produce offical binaries. Goreleaser strips the "v" prefix from version strings by default. So update the nvim-go version check to also recognize that version format.

For upstream's explanation of this, see:
https://github.com/golangci/golangci-lint/issues/5069#issuecomment-2416983705

This fixes an error I've seen when a release version of `golangci-lint` v2 is in `$PATH`.